### PR TITLE
[bug/#9] Scripts 폴더와 스크립트의 누락된 *.meta 파일 업로드

### DIFF
--- a/Assets/Scripts.meta
+++ b/Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 87caaa39af34c304a96c90671ab162d3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/HeroMoveControl.cs.meta
+++ b/Assets/Scripts/HeroMoveControl.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0152c5649693ba04d91705c51b17084f

--- a/Assets/Scripts/HeroStat.cs.meta
+++ b/Assets/Scripts/HeroStat.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 55f2c9046b5ef2243b8a047f10c2c3fa

--- a/Assets/Scripts/ZombieStat.cs
+++ b/Assets/Scripts/ZombieStat.cs
@@ -1,4 +1,3 @@
-using System.Threading.Tasks.Dataflow;
 using UnityEngine;
 
 public class ZombieStat : MonoBehaviour
@@ -22,6 +21,6 @@ public class ZombieStat : MonoBehaviour
     }
     void DestroyZombie()
     {
-        DestroyZombie(gameObject);
+        Destroy(gameObject);
     }
 }

--- a/Assets/Scripts/ZombieStat.cs.meta
+++ b/Assets/Scripts/ZombieStat.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 03efb2b00b4d94e95b2c16598f1e0cf6


### PR DESCRIPTION
## 🚀 Background
- 누락된 Scripts 폴더, 히어로 스탯 스크립트, 캐릭터 이동 스크립트의 meta 파일 업로드

## 🥥 Changes
- Assets/Scripts.meta 경로에 해당 파일 추가
- Assets/Scripts/HeroStat.cs.meta 경로에 해당 파일 추가
- Assets/Scripts/HeroMoveControl.cs.meta 경로에 해당 파일 추가


## ⚓ Related Issue
- closes #9 
