### PR TITLE
[FR-041/feat/#12] 카메라 고정/시야 이동

### DIFF
--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -131,6 +131,7 @@ GameObject:
   - component: {fileID: 519420031}
   - component: {fileID: 519420029}
   - component: {fileID: 519420030}
+  - component: {fileID: 519420033}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -256,6 +257,21 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0.049}
+--- !u!114 &519420033
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519420028}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ab29d93278da5a944a9f18f4c98ae995, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: '::'
+  target: {fileID: 1380755839}
+  smoothSpeed: 0.1
+  offset: {x: 0, y: 0, z: -10}
 --- !u!1 &619394800
 GameObject:
   m_ObjectHideFlags: 0
@@ -637,6 +653,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 55f2c9046b5ef2243b8a047f10c2c3fa, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::HeroStat
+  speed: 0
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/CameraFollow.cs
+++ b/Assets/Scripts/CameraFollow.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+
+public class CameraFollow : MonoBehaviour
+{
+    public Transform target; // 따라갈 객체(요소 설정)
+    public float smoothSpeed = 0.1f; // 자연스러운 화면 이동을 위한 이동 지연 속도 정의
+
+    // offset 지원 (플레이어 기준 카메라 위치)
+    // 2D 탑뷰 -> 카메라 z 좌표를 -10으로 초기화
+    public Vector3 offset = new Vector3(0, 0, -10f);
+ 
+    void LateUpdate()
+    {
+        if (target == null) return;
+
+        // offset을 적용한 위치 계산
+        Vector3 desiredPosition = target.position + offset;
+        transform.position = Vector3.Lerp(transform.position, desiredPosition, smoothSpeed);
+    }
+}

--- a/Assets/Scripts/CameraFollow.cs.meta
+++ b/Assets/Scripts/CameraFollow.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ab29d93278da5a944a9f18f4c98ae995


### PR DESCRIPTION
## 🚀 Background
- 기존 FR-041/feat/#11 브랜치의 conflict 오류로 새 브랜치를 생성해 기능을 다시 추가
- 메인 카메라의 화면에 히어로 캐릭터를 항상 중심에 있도록 설정
- 플레이어 이동 속도에 맞게 카메라 이동 기능 추가
- 메인 카메라의 이동 지연을 통한 자연스러운 화면 이동 기능 추가

## 🥥 Changes
- Main Camera의 컴포넌트 스크립트 CameraFollow 추가
- CameraFollow 스크립트의 Target을 Hero 오브젝트로 설정
- Smooth Speed, Offset 기능 추가

```
public class CameraFollow : MonoBehaviour
{
    public Transform target; // 따라갈 객체(요소 설정)
    public float smoothSpeed = 0.1f; // 자연스러운 화면 이동을 위한 이동 지연 속도 정의

    // offset 지원 (플레이어 기준 카메라 위치)
    // 2D 탑뷰 -> 카메라 z 좌표를 -10으로 초기화
    public Vector3 offset = new Vector3(0, 0, -10f);
 
    void LateUpdate()
    {
        if (target == null) return;

        // offset을 적용한 위치 계산
        Vector3 desiredPosition = target.position + offset;
        transform.position = Vector3.Lerp(transform.position, desiredPosition, smoothSpeed);
    }
}
```


## 🧪 Testing
- Hero 오브젝트 이동에 따라 메인 카메라가 이동하는가
- 이동 속도에 따라 화면이 적절한 지연 속도로 이동하는가

## 📸 Screenshots
https://github.com/user-attachments/assets/c0a29749-ee61-45d2-95ef-fe8e2c5effc8

## 🪪 ID
- FR-041-1-1
- FR-041-1-2

## ⚓ Related Issue
- closes #11
