### PR TITLE
[FR-045/feat/#34] 히어로 상호작용 구현

### DIFF
--- a/Assets/Prefabs/Zombie.prefab
+++ b/Assets/Prefabs/Zombie.prefab
@@ -12,7 +12,10 @@ GameObject:
   - component: {fileID: 7802953469812169975}
   - component: {fileID: 4901052238921568252}
   - component: {fileID: 9161328671418450196}
-  m_Layer: 0
+  - component: {fileID: -7325215797412698943}
+  - component: {fileID: -6914990703295645560}
+  - component: {fileID: -2052348383094473455}
+  m_Layer: 3
   m_Name: Zombie
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -138,3 +141,73 @@ MonoBehaviour:
   collisionTilemap: {fileID: 0}
   MoveInterval: 1
   target: {fileID: 0}
+--- !u!114 &-7325215797412698943
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6989195092527803693}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 03efb2b00b4d94e95b2c16598f1e0cf6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::ZombieStat
+--- !u!114 &-6914990703295645560
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6989195092527803693}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f27fa371b66006c44823b81d30e6b5d1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::ZombieInteraction
+--- !u!61 &-2052348383094473455
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6989195092527803693}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 0.3125, y: 0.6875}
+    newSize: {x: 0.3125, y: 0.6875}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 0.3125, y: 0.6875}
+  m_EdgeRadius: 0

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -84377,7 +84377,7 @@ GameObject:
   - component: {fileID: 917889967}
   - component: {fileID: 917889968}
   m_Layer: 3
-  m_Name: TestITem
+  m_Name: TestItem
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -84929,6 +84929,170 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::HeroInteraction
   HeroMoveControl: {fileID: 0}
+--- !u!1 &2048582471
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2048582475}
+  - component: {fileID: 2048582474}
+  - component: {fileID: 2048582473}
+  - component: {fileID: 2048582472}
+  - component: {fileID: 2048582476}
+  m_Layer: 3
+  m_Name: TestZombie
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!61 &2048582472
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2048582471}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!114 &2048582473
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2048582471}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f27fa371b66006c44823b81d30e6b5d1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::ZombieInteraction
+--- !u!212 &2048582474
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2048582471}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 30
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &2048582475
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2048582471}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 9.5, y: -4.5, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2048582476
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2048582471}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 03efb2b00b4d94e95b2c16598f1e0cf6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::ZombieStat
+  player: {fileID: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -84939,3 +85103,4 @@ SceneRoots:
   - {fileID: 1380755839}
   - {fileID: 965909448}
   - {fileID: 917889966}
+  - {fileID: 2048582475}

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -84364,6 +84364,156 @@ Tilemap:
     e31: 0
     e32: 0
     e33: 1
+--- !u!1 &917889964
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 917889966}
+  - component: {fileID: 917889965}
+  - component: {fileID: 917889967}
+  - component: {fileID: 917889968}
+  m_Layer: 3
+  m_Name: TestITem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &917889965
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 917889964}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 30
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &917889966
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 917889964}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 6.5, y: -5.5, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &917889967
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 917889964}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f8ed8c22921038d429b0f1d1b2a07172, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: '::'
+--- !u!61 &917889968
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 917889964}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
 --- !u!1 &945260222
 GameObject:
   m_ObjectHideFlags: 0
@@ -84498,6 +84648,50 @@ Transform:
   m_Children:
   - {fileID: 567846182}
   - {fileID: 884975782}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1269963532
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1269963534}
+  - component: {fileID: 1269963533}
+  m_Layer: 0
+  m_Name: _InventoryManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1269963533
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1269963532}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f135c7e5dba85dd4c94e3dbd160fd08d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::InventoryManager
+--- !u!4 &1269963534
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1269963532}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 13.26524, y: 2.39365, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1380755837
@@ -84734,12 +84928,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bd11fb6cb0da4d24e8fb06b9c1426192, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::HeroInteraction
-  heroMove: {fileID: 0}
+  HeroMoveControl: {fileID: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 519420032}
   - {fileID: 619394802}
+  - {fileID: 1269963534}
   - {fileID: 1380755839}
   - {fileID: 965909448}
+  - {fileID: 917889966}

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -85092,7 +85092,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 03efb2b00b4d94e95b2c16598f1e0cf6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::ZombieStat
-  player: {fileID: 0}
+  player: {fileID: 1380755839}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -84,7 +84,7 @@ public class GameManager : MonoBehaviour
             CurrentPhase = Phase.Day;
             Debug.Log($"[☀️ {CurrentDay}] 낮 시작! 좀비 수: {ZombieSpawnCount}");
             // 5초마다 페이즈 변경
-            yield return new WaitForSeconds(5f);
+            yield return new WaitForSeconds(30f);
 
             // 밤
             CurrentPhase = Phase.Night;

--- a/Assets/Scripts/HeroInteraction.cs
+++ b/Assets/Scripts/HeroInteraction.cs
@@ -3,19 +3,22 @@ using UnityEngine.InputSystem;
 
 public class HeroInteraction : MonoBehaviour
 {
-    public HeroMoveControl heroMove;
+    public HeroMoveControl HeroMoveControl;
     private Vector2 viewDirection;
-    private LayerMask interactableLayer; // 컴마로 구분해서 더 넣을 수 있음.
+    // 컴마로 구분해서 더 넣을 수 있음.
+    // rayCast의 성능 향상을 위해 interactableLayer를 가진 요소만 충돌요소로 본다.
+    private LayerMask interactableLayer; 
+    
 
     void Start()
     {
         interactableLayer = LayerMask.GetMask("Interactable");
-        heroMove = GetComponent<HeroMoveControl>();
-        if (heroMove == null) Debug.LogError("컴포넌트 참조 에러");
+        HeroMoveControl = GetComponent<HeroMoveControl>();
+        if (HeroMoveControl == null) Debug.LogError("컴포넌트 참조 에러");
     }
     public void OnInteract(InputAction.CallbackContext context)
     {
-        if (context.performed) // 눌렀을 때만 실행
+        if (context.performed) // 눌렀을 때만 실행 (spacebar)
         {
             tryInteraction();
             // Debug.Log("interaction!");
@@ -23,11 +26,13 @@ public class HeroInteraction : MonoBehaviour
     }
     void tryInteraction()
     {
-        viewDirection = heroMove.CurrentViewDirection;
+        // 시야 방향으로 rayCast 진행
+        viewDirection = HeroMoveControl.CurrentViewDirection;
         rayCast(viewDirection);
     }
     void rayCast(Vector2 viewDirection)
     {
+        // rayCast 설정
         RaycastHit2D hit = Physics2D.Raycast(
             transform.position,
             viewDirection,
@@ -38,11 +43,12 @@ public class HeroInteraction : MonoBehaviour
         Debug.DrawRay(transform.position, viewDirection * 1.0f, Color.red, 1.0f);
         if (hit.collider != null)
         {
-            Debug.Log(hit.collider);
+            // Debug.Log($"{hit.collider} hit");
+            // IInteractable 규칙이 있는 오브젝트의 경우, OnInteract 를 실행한다.
             IInteractable targetObj = hit.collider.GetComponent<IInteractable>();
             if(targetObj != null)
             {
-                Debug.Log(targetObj);
+                // Debug.Log($"{targetObj} interaction target");
                 targetObj.OnInteract();
             }
         }

--- a/Assets/Scripts/HeroMoveControl.cs
+++ b/Assets/Scripts/HeroMoveControl.cs
@@ -1,6 +1,10 @@
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.InputSystem;
+
+/// tap, hold 구분 x
+/// hold로 모든 동작 처리
+/// input 에 입력값이 들어오면 무조건 changeViewDirection 을 실행 함.
 public class HeroMoveControl : MonoBehaviour
 {
     private Vector2 currentViewDirection = new Vector2(0f,-1f); // 시야 방향. 외부 참조 변수
@@ -9,13 +13,14 @@ public class HeroMoveControl : MonoBehaviour
         get { return currentViewDirection; }
     }
     public float moveSpeed = 5f; // 초기 이동 속도
-    private Rigidbody2D rb; // 2D 물리 엔진 컴포넌트 참조
     private Vector2 targetPosition; // 이동 위치
+    private Rigidbody2D rb; // 2D 물리 엔진 컴포넌트 참조
     // Input Actions Asset을 public으로 참조
     public InputActionAsset inputActions;
     private InputAction moveAction;
     private Vector2 moveInput;
-    private bool isMoving = false; // 그리드 단위 이동 변수. true 일 경우 입력을 무시하고 1그리드 이동
+    // 그리드 단위 이동 변수. true 일 경우 입력을 무시하고 1그리드 이동
+    private bool isMoving = false; 
     [SerializeField]
     private Vector2 initHeroPosition = new Vector2(0.5f, 0.5f); // Hero 초기화 좌표.
     void Awake()
@@ -52,15 +57,6 @@ public class HeroMoveControl : MonoBehaviour
         // InputSystem 내부에서 4방향 통제 불가로 인한 후처리
         if (moveInput.x != 0f && moveInput.y != 0f) moveInput.x = 0f; 
     }
-    // void FixedUpdate()
-    // {
-    //     // 물리 이동 처리
-    //     if (moveAction != null)
-    //     {
-    //         Vector2 newPos = rb.position + moveInput * moveSpeed * Time.fixedDeltaTime;
-    //         rb.MovePosition(newPos);
-    //     }
-    // }
 
     // 그리드 단위 이동
     void FixedUpdate()
@@ -80,7 +76,7 @@ public class HeroMoveControl : MonoBehaviour
                 {
                     isMoving = true;
                     targetPosition += moveInput.normalized * 1.0f;
-                    currentViewDirection = (targetPosition - rb.position).normalized; // 플레이어 시야 방향. (외부 사용)
+                    changeViewDirection(moveInput.normalized);
                 } // 입력값이 없으면 해당 그리드에서 멈춘다.
                 else
                 {
@@ -96,8 +92,18 @@ public class HeroMoveControl : MonoBehaviour
             {
                 isMoving = true;
                 targetPosition = rb.position + moveInput.normalized * 1.0f;
-                currentViewDirection = (targetPosition - rb.position).normalized; // 플레이어 시야 방향. (외부 사용)
+                changeViewDirection(moveInput.normalized);
             }
         }
+    }
+    // changeViewDirection
+    // 시야 방향 변경 동작은 해당 함수에서 처리함.
+    void changeViewDirection(Vector2 inputDir)
+    {
+        // input direction 과 currentViewDirection 이 다른 경우 변경을 진행 함.
+        if (currentViewDirection != inputDir.normalized)
+        {
+            currentViewDirection = inputDir.normalized;
+        } 
     }
 }

--- a/Assets/Scripts/HeroStat.cs
+++ b/Assets/Scripts/HeroStat.cs
@@ -1,12 +1,23 @@
 using UnityEngine;
 
-public class HeroStat : MonoBehaviour
+public class HeroStat : MonoBehaviour 
 {
-    int hp;
+    
+    public static HeroStat Instance { get; private set; }
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(this.gameObject);
+            return;
+        }
+        Instance = this;
+    }
+    private int hp;
     public int speed;
-    int hunger;
+    private int hunger;
 
-    bool isSurvival;
+    private bool isSurvival;
 
     void SpeedControl()
     {

--- a/Assets/Scripts/IInteractable.cs
+++ b/Assets/Scripts/IInteractable.cs
@@ -1,6 +1,0 @@
-// 규칙 추가 IInteractable 을 가진 컴포넌트는 OnInteract 함수를 필수적으로 가지고 있어야 하며
-// 가지고 있지 않은 경우 에러가 발생한다. HeroInteraction 에서 Object의 OnInteract를 실행시킬 수 있음.
-public interface IInteractable
-{
-    void OnInteract();
-}

--- a/Assets/Scripts/IInteractable.cs.meta
+++ b/Assets/Scripts/IInteractable.cs.meta
@@ -1,2 +1,0 @@
-fileFormatVersion: 2
-guid: 08d4b5c3ad3b57946adf1cda5617a428

--- a/Assets/Scripts/InventoryManager.cs
+++ b/Assets/Scripts/InventoryManager.cs
@@ -1,0 +1,42 @@
+using UnityEngine;
+using System.Collections.Generic;
+public class InventoryManager : MonoBehaviour
+{
+    // 읽기만 가능하고 쓰기는 클래스 내부에서만 가능하도록
+    public static InventoryManager Instance { get; private set; }
+    private Dictionary<string, int> Inventory = new Dictionary<string, int>();
+
+    private void Awake() {
+        if (Instance != null && Instance != this)
+        {
+            // 이미 존재한다면, 새로 생성된 자신을 파괴하여 중복 방지
+            Destroy(this.gameObject);
+            return;
+        }
+        Instance = this;
+    }
+    public void addItem(string itemName, int itemCnt)
+    {
+        if (Inventory.ContainsKey(itemName))
+        {
+            Inventory[itemName] += itemCnt;
+            Debug.Log(itemName);
+        }
+        else
+        {
+            Inventory.Add(itemName, itemCnt);
+            Debug.Log($"{itemName} 추가");
+        }
+    }
+    public int getItemQuantity(string itemName)
+    {
+        if (Inventory.ContainsKey(itemName))
+        {
+            return Inventory[itemName];
+        }
+        else
+        {
+            return 0;
+        }
+    }
+}

--- a/Assets/Scripts/InventoryManager.cs.meta
+++ b/Assets/Scripts/InventoryManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f135c7e5dba85dd4c94e3dbd160fd08d

--- a/Assets/Scripts/ZombieMove.cs
+++ b/Assets/Scripts/ZombieMove.cs
@@ -151,7 +151,7 @@ public class ZombieMove : MonoBehaviour
 
         if (findTarget)
         {
-            Debug.Log("find!!!");
+            // Debug.Log("find!!!");
             // ─────────────────────────────────────────────────────
             // [수정] 추격 시에도 "연속 밀기" 대신 "한 칸 스텝"으로 통일
             //  - 왜? 연속 MovePosition은 라인을 타거나 코너에서 관통 위험이 있음.
@@ -192,7 +192,7 @@ public class ZombieMove : MonoBehaviour
         }
         else
         {
-            Debug.Log("haa....");
+            // Debug.Log("haa....");
             // 랜덤 배회: 기존 로직 유지(단, CanStep/스냅의 효과를 그대로 받음)
             if (stepping) return;
 

--- a/Assets/Scripts/ZombieStat.cs
+++ b/Assets/Scripts/ZombieStat.cs
@@ -5,12 +5,11 @@ public class ZombieStat : MonoBehaviour
     int hp = 1000;
     int speed;
     int power = 1000;
-    public Transform player;
     private HeroStat heroStat;
   
     void Start()
     {
-        heroStat = player.GetComponent<HeroStat>();
+        heroStat = HeroStat.Instance;
         if (heroStat != null) speed = (int)(heroStat.speed * 1.1f);
         else speed = 1000;
     }

--- a/Assets/Scripts/ZombieStat.cs
+++ b/Assets/Scripts/ZombieStat.cs
@@ -19,8 +19,12 @@ public class ZombieStat : MonoBehaviour
     {
         if (hp <= 0) DestroyZombie();
     }
-    void DestroyZombie()
+    void DestroyZombie() // public 으로 변경하였음
     {
         Destroy(gameObject);
+    }
+    public void takeDamage(int damage) // zombie hp 데이터 타입 변경 필요성 있음
+    {
+        hp -= damage;
     }
 }

--- a/Assets/Scripts/interaction_cs.meta
+++ b/Assets/Scripts/interaction_cs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 415e9b94c90202d4c9f2054e1c74f21d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/interaction_cs/IInteractable.cs
+++ b/Assets/Scripts/interaction_cs/IInteractable.cs
@@ -1,0 +1,8 @@
+// 규칙 추가 
+// 상호작용이 가능한 오브젝트에는 IInteractable 을 
+// IInteractable 을 가진 컴포넌트는 OnInteract 함수를 필수적으로 가지고 있어야 하며
+// 가지고 있지 않은 경우 에러가 발생한다. HeroInteraction 에서 Object의 OnInteract를 실행시킬 수 있음.
+public interface IInteractable
+{
+    void OnInteract();
+}

--- a/Assets/Scripts/interaction_cs/IInteractable.cs.meta
+++ b/Assets/Scripts/interaction_cs/IInteractable.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 08d4b5c3ad3b57946adf1cda5617a428

--- a/Assets/Scripts/interaction_cs/ItemInteraction.cs
+++ b/Assets/Scripts/interaction_cs/ItemInteraction.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+public class ItemInteraction : MonoBehaviour, IInteractable
+{
+    private string ItemName = "test";
+    private int ItemCnt = 1;
+    public void OnInteract()
+    {
+        if(InventoryManager.Instance != null)
+        {
+            InventoryManager.Instance.addItem(ItemName, ItemCnt);
+            Destroy(gameObject);
+        }
+    }
+}

--- a/Assets/Scripts/interaction_cs/ItemInteraction.cs.meta
+++ b/Assets/Scripts/interaction_cs/ItemInteraction.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f8ed8c22921038d429b0f1d1b2a07172

--- a/Assets/Scripts/interaction_cs/NpcInteracrion.cs.meta
+++ b/Assets/Scripts/interaction_cs/NpcInteracrion.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 582ace598ee209c468c124993bcb9a4a

--- a/Assets/Scripts/interaction_cs/ZombieInteraction.cs
+++ b/Assets/Scripts/interaction_cs/ZombieInteraction.cs
@@ -1,9 +1,22 @@
+using System.Runtime.CompilerServices;
 using UnityEngine;
 
 public class ZombieInteraction : MonoBehaviour, IInteractable
 {
+    private ZombieStat zombieStat;
+    private HeroStat heroStat;
     public void OnInteract()
     {
-        
+        // 필수 변경
+        // 임의 설정 heroStat.power를 추가해야 할듯.
+        zombieStat.takeDamage(200); 
+        Debug.Log("attack!");
+    }
+    private void Start()
+    {
+        zombieStat = GetComponent<ZombieStat>();
+        heroStat = GetComponent<HeroStat>();
+        if(heroStat == null)Debug.Log("hero_stat reference error");
+        if (zombieStat == null) Debug.Log("zombie_stat reference error");
     }
 }

--- a/Assets/Scripts/interaction_cs/ZombieInteraction.cs
+++ b/Assets/Scripts/interaction_cs/ZombieInteraction.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+public class ZombieInteraction : MonoBehaviour, IInteractable
+{
+    public void OnInteract()
+    {
+        
+    }
+}

--- a/Assets/Scripts/interaction_cs/ZombieInteraction.cs
+++ b/Assets/Scripts/interaction_cs/ZombieInteraction.cs
@@ -15,7 +15,7 @@ public class ZombieInteraction : MonoBehaviour, IInteractable
     private void Start()
     {
         zombieStat = GetComponent<ZombieStat>();
-        heroStat = GetComponent<HeroStat>();
+        heroStat = zombieStat.player.GetComponent<HeroStat>();
         if(heroStat == null)Debug.Log("hero_stat reference error");
         if (zombieStat == null) Debug.Log("zombie_stat reference error");
     }

--- a/Assets/Scripts/interaction_cs/ZombieInteraction.cs
+++ b/Assets/Scripts/interaction_cs/ZombieInteraction.cs
@@ -15,7 +15,7 @@ public class ZombieInteraction : MonoBehaviour, IInteractable
     private void Start()
     {
         zombieStat = GetComponent<ZombieStat>();
-        heroStat = zombieStat.player.GetComponent<HeroStat>();
+        heroStat = HeroStat.Instance;
         if(heroStat == null)Debug.Log("hero_stat reference error");
         if (zombieStat == null) Debug.Log("zombie_stat reference error");
     }

--- a/Assets/Scripts/interaction_cs/ZombieInteraction.cs.meta
+++ b/Assets/Scripts/interaction_cs/ZombieInteraction.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f27fa371b66006c44823b81d30e6b5d1


### PR DESCRIPTION
## 🚀 Background

FR-022-1-1 | 상호작용 가능 | 모든 오브젝트는 맵 내 생성 당시 상호작용 가능 상태
-- | -- | --
FR-022-1-2 | 선택됨 상태 | 플레이어가 아이템에 접근하면 선택됨 상태로 전환
FR-022-1-3 | 상호작용 상태 | 키 입력이 발생하면 상호작용 상태로 전환
FR-022-2-1 | 대상: 좀비 | 대상이 “좀비”일 경우 공격
FR-022-2-3 | 대상: 아이템 | 대상이 “아이템”일 경우 인벤토리에 저장되고 동시에 소멸 이펙트와 함께 사라짐

나머지 미구현

## 🥥 Changes
- Scripts/interaction_cs/ 경로에 파일 추가
- InventoryManager 파일 추가
- HeroStat 싱글톤으로 변경
- Zombie prefab 컴포넌트 추가.

## 🧪 Testing

## 📸 Screenshots

## ✍🏻 References

## 🪪 ID
FR-022-1-1 
FR-022-1-2
FR-022-1-3
FR-022-2-1 
FR-022-2-3
## ⚓ Related Issue
