### PR TITLE
[FR-ITEM/fix/#87] 초과 회복 오류 수정

### DIFF
--- a/Assets/Scripts/HeroStat.cs
+++ b/Assets/Scripts/HeroStat.cs
@@ -107,7 +107,7 @@ public class HeroStat : MonoBehaviour
             // 1초마다 허기가 10씩 감소
             yield return new WaitForSeconds(1f);
             hunger -= 10f;
-
+            Debug.Log(hunger);
             // 허기가 음수가 되지 않도록 보정
             if (hunger < 0) hunger = 0;
 

--- a/Assets/Scripts/Item_cs/MedicineData.cs
+++ b/Assets/Scripts/Item_cs/MedicineData.cs
@@ -30,32 +30,49 @@ public class MedicineData : ItemData, IUsable
     {
         heroStat = HeroTransform.GetComponent<HeroStat>();
 
+        // hp 회복 아이템 사용 시.
         if (whichStat.Contains("hp"))
         {
             currentStat = heroStat.hp;
             maxAmount = heroStat.maxHp;
+            // 현재 스탯이 maxAmount 인 경우 사용을 막는다
             if (currentStat == maxAmount)
             {
                 Debug.Log("한계치 초과");
+                return;
+            }
+            // 현재 스탯에 회복량을 더했을 때 최고치를 넘는 경우 최대치로 스탯을 조정
+            else if (currentStat + healAmount[0] >= maxAmount)
+            {
+                heroStat.hp = maxAmount;
                 return;
             }
             heroStat.hp += healAmount[0];
             Debug.Log("hp회복");
         }
+        // hp 회복 아이템 사용 시.
         if (whichStat.Contains("hunger"))
         {
             currentStat = heroStat.hunger;
             maxAmount = heroStat.maxHunger;
-            if (currentStat == maxAmount)
+            // 현재 스탯이 maxAmount 인 경우 사용을 막는다
+            if (currentStat>=maxAmount)
             {
                 Debug.Log("한계치 초과");
                 return;
             }
+            else if (currentStat + healAmount[1] >= maxAmount)
+            {
+                heroStat.hunger = maxAmount;
+                return;
+            }
+            // 현재 스탯에 회복량을 더했을 때 최고치를 넘는 경우 최대치로 스탯을 조정
             heroStat.hunger += healAmount[1];
             Debug.Log("포만감 회복");
         }
         if (whichStat.Contains("speed"))
         {
+            // 이동속도 증가 코루틴 적용.
             heroStat.ActiveHeroSpeedBoost(buffDuration,healAmount[2]);
         }
     }


### PR DESCRIPTION
## 🚀 Background
- 단순 오류 수정
- 아이템 초과 회복 오류

## 🥥 Changes
- 실제로 구현하거나 바꾼 부분에 대한 설명

## 🧪 Testing
- 작동 및 연동 확인 내용 (체크리스트 권장)

## 📸 Screenshots
- 화면 동영상이나 사진 캡쳐

## ✍🏻 References
- 참고한 레퍼런스

## 🪪 ID
- 개발 명세서에 기재된 ID

## ⚓ Related Issue
- closes #(이슈번호)
