### PR TITLE
[FR-Item/feat/#97] 아이템 드롭

### DIFF
--- a/Assets/Prefabs/TeddyBear.prefab
+++ b/Assets/Prefabs/TeddyBear.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &6989195092527803693
+--- !u!1 &2287141480163034400
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,43 +8,42 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 6875743572020977146}
-  - component: {fileID: 7802953469812169975}
-  - component: {fileID: 4901052238921568252}
-  - component: {fileID: 9161328671418450196}
-  - component: {fileID: -7325215797412698943}
-  - component: {fileID: -6914990703295645560}
-  - component: {fileID: -2052348383094473455}
-  - component: {fileID: 1467303946012295050}
+  - component: {fileID: 5269913728829531272}
+  - component: {fileID: 603641794604716522}
+  - component: {fileID: 5220239032760274140}
+  - component: {fileID: 768547217877965857}
+  - component: {fileID: 3642441484333109082}
+  - component: {fileID: 2111366661069429078}
+  - component: {fileID: 8725439281975841835}
   m_Layer: 3
-  m_Name: NormalZombie
-  m_TagString: Zombie
+  m_Name: TeddyBear
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &6875743572020977146
+--- !u!4 &5269913728829531272
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6989195092527803693}
+  m_GameObject: {fileID: 2287141480163034400}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.53, y: -4.2, z: 0}
-  m_LocalScale: {x: 1.4, y: 1.4, z: 2}
+  m_LocalPosition: {x: -1.08, y: -3.16, z: 0}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &7802953469812169975
+--- !u!212 &603641794604716522
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6989195092527803693}
+  m_GameObject: {fileID: 2287141480163034400}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -85,33 +84,33 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 15
-  m_Sprite: {fileID: -2842336560070018383, guid: 01b9056965836f9409a0f688be79aabf, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 0.7735849, g: 0, b: 0.6972833, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 0.3125, y: 0.6875}
+  m_Size: {x: 1, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!50 &4901052238921568252
+--- !u!50 &5220239032760274140
 Rigidbody2D:
   serializedVersion: 5
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6989195092527803693}
-  m_BodyType: 0
+  m_GameObject: {fileID: 2287141480163034400}
+  m_BodyType: 2
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
   m_UseAutoMass: 0
   m_Mass: 1
   m_LinearDamping: 0
   m_AngularDamping: 0.05
-  m_GravityScale: 0
+  m_GravityScale: 1
   m_Material: {fileID: 0}
   m_IncludeLayers:
     serializedVersion: 2
@@ -122,63 +121,14 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 4
---- !u!114 &9161328671418450196
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6989195092527803693}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: eb4f6411332844c4c87db781e6e76958, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::ZombieMove
-  speed: 2.5
-  grid: 5
-  limitGrid: 3
-  attackDelay: 1
-  collisionTilemap: {fileID: 0}
-  MoveInterval: 1
-  target: {fileID: 0}
---- !u!114 &-7325215797412698943
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6989195092527803693}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 03efb2b00b4d94e95b2c16598f1e0cf6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::ZombieStat
-  type: 0
-  dropItem: {fileID: 2287141480163034400, guid: 7f140e7a38ddecd48bccfdb655f6529b, type: 3}
-  dropRate: 80
-  BaseHp: 1000
-  BaseSpeedFactor: 1.1
-  BasePower: 40
---- !u!114 &-6914990703295645560
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6989195092527803693}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f27fa371b66006c44823b81d30e6b5d1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::ZombieInteraction
---- !u!61 &-2052348383094473455
+  m_Constraints: 0
+--- !u!61 &768547217877965857
 BoxCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6989195092527803693}
+  m_GameObject: {fileID: 2287141480163034400}
   m_Enabled: 1
   serializedVersion: 3
   m_Density: 1
@@ -210,33 +160,49 @@ BoxCollider2D:
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 0.3125, y: 0.6875}
-    newSize: {x: 0.3125, y: 0.6875}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
     adaptiveTilingThreshold: 0.5
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
-  m_Size: {x: 0.3125, y: 0.6875}
+  m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
---- !u!95 &1467303946012295050
-Animator:
-  serializedVersion: 7
+--- !u!114 &3642441484333109082
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6989195092527803693}
+  m_GameObject: {fileID: 2287141480163034400}
   m_Enabled: 1
-  m_Avatar: {fileID: 0}
-  m_Controller: {fileID: 9100000, guid: 328c70f387ecf424abe8c5ed8b773c9c, type: 2}
-  m_CullingMode: 0
-  m_UpdateMode: 0
-  m_ApplyRootMotion: 0
-  m_LinearVelocityBlending: 0
-  m_StabilizeFeet: 0
-  m_AnimatePhysics: 0
-  m_WarningMessage: 
-  m_HasTransformHierarchy: 1
-  m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorStateOnDisable: 0
-  m_WriteDefaultValuesOnDisable: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f8ed8c22921038d429b0f1d1b2a07172, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::ItemInteraction
+--- !u!114 &2111366661069429078
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2287141480163034400}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7fdfa22a50422f14f9d2103397f2d230, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::ItemOccupancy
+  tilemap: {fileID: 0}
+--- !u!114 &8725439281975841835
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2287141480163034400}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e05586a9c91e10c47beaac541c4109f1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::FieldItems
+  count: 1

--- a/Assets/Prefabs/TeddyBear.prefab.meta
+++ b/Assets/Prefabs/TeddyBear.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7f140e7a38ddecd48bccfdb655f6529b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/ZombiePrefabs/NormalZombie.prefab
+++ b/Assets/Prefabs/ZombiePrefabs/NormalZombie.prefab
@@ -156,7 +156,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::ZombieStat
   type: 0
   dropItem: {fileID: 2287141480163034400, guid: 7f140e7a38ddecd48bccfdb655f6529b, type: 3}
-  dropRate: 80
+  dropRate: 0.8
   BaseHp: 1000
   BaseSpeedFactor: 1.1
   BasePower: 40

--- a/Assets/Scripts/ZombieMove.cs
+++ b/Assets/Scripts/ZombieMove.cs
@@ -143,6 +143,15 @@ public class ZombieMove : MonoBehaviour
             hasReservedNext = false;
         }
     }
+    public void CallDestroy()
+    {
+        GridOccupancy.Release(collisionTilemap, currentCell, this);
+        if (hasReservedNext)
+        {
+            GridOccupancy.Release(collisionTilemap, reservedTargetCell, this);
+            hasReservedNext = false;
+        }
+    }
 
     void DoAttack()
     {

--- a/Assets/Scripts/ZombieStat.cs
+++ b/Assets/Scripts/ZombieStat.cs
@@ -1,3 +1,5 @@
+using NUnit.Framework;
+using Unity.Mathematics;
 using UnityEngine;
 
 // 좀비의 유형을 정의하는 Enum
@@ -13,6 +15,13 @@ public class ZombieStat : MonoBehaviour
     // 좀비 유형 설정
     [Header("Zombie Type")]
     public ZombieType type = ZombieType.Normal; // 좀비의 유형
+    [Header("drop item")]
+    public GameObject dropItem;
+    [Header("drop rate - float")]
+    public float dropRate;
+    [Header("점유 해제 타일 맵")]
+
+
 
     // 기본 스탯 설정
     [Header("Base Stats")]
@@ -103,6 +112,9 @@ public class ZombieStat : MonoBehaviour
 
     public void DestroyZombie() 
     {
+        // 좀비의 그리드 점유를 해제 하고 아이템을 드롭 한 후, destroy가 진행됨.
+        zombieMove.CallDestroy();
+        itemDrop();
         Destroy(gameObject);
     }
     
@@ -111,5 +123,11 @@ public class ZombieStat : MonoBehaviour
     {
         currentHp -= damage;
         if(currentHp <= 0) DestroyZombie();
+    }
+    // 아이템 드롭
+    public void itemDrop()
+    {
+        var isDrop = UnityEngine.Random.Range(0f,1f) < dropRate;
+        if(isDrop) Instantiate(dropItem,transform.position,Quaternion.identity);
     }
 }

--- a/Assets/Scripts/ZombieStat.cs
+++ b/Assets/Scripts/ZombieStat.cs
@@ -19,7 +19,6 @@ public class ZombieStat : MonoBehaviour
     public GameObject dropItem;
     [Header("drop rate - float")]
     public float dropRate;
-    [Header("점유 해제 타일 맵")]
 
 
 


### PR DESCRIPTION

## 🚀 Background
- 아이템 드롭 기능 추가
- 좀비 죽을 때 드롭.
- 인스펙터에서 프리팹 전달하고 확률 지정 가능.
- 노말좀비에만 적용하였음. 확률도 80% 임의 지정해둠.
- 이미지 변경 필요. 사이즈도 임의 지정해두었음
- 일단 곰인형만 떨구게 해놨는데 추후 확장은 쉬우니까 드롭 아이템 조정 필요 시 논의 후 변경 가능
- 좀비 사망 -> 좀비 점유 그리드 해제 -> 아이템 생성 -> 좀비 destroy  순서로 진행됨. 
- 좀비 점유 그리드 임의 해제를 위해 ZombieMove.cs 에 CallDestroy() 추가하였음.
- 스폰 매니저에서 관리 한다고 하면 바로 코드 변경 가능.
## 🥥 Changes
- 실제로 구현하거나 바꾼 부분에 대한 설명

## 🧪 Testing
- 작동 및 연동 확인 내용 (체크리스트 권장)

## 📸 Screenshots
<img width="676" height="368" alt="image" src="https://github.com/user-attachments/assets/94eb449f-d3e6-4398-b9b5-d046ac9e1585" />

## ✍🏻 References
- 참고한 레퍼런스

## 🪪 ID
- 개발명세서 미기제

## ⚓ Related Issue
