### PR TITLE
[FR-023/feat/#106] 퀵슬롯, 장비슬롯 구현

### DIFF
--- a/Assets/Prefabs/HealItem.prefab
+++ b/Assets/Prefabs/HealItem.prefab
@@ -209,6 +209,7 @@ MonoBehaviour:
   itemType: 0
   itemName: Heal1
   itemImage: {fileID: 2619156217251398772, guid: a4d9ddf8d7e6b0146a1fdbc0159db0f4, type: 3}
+  itemDataAsset: {fileID: 11400000, guid: 7cce2fb019d690f45aa42f685f253d64, type: 2}
 --- !u!114 &3138272015581814652
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/LanternItem.prefab
+++ b/Assets/Prefabs/LanternItem.prefab
@@ -209,6 +209,7 @@ MonoBehaviour:
   itemType: 2
   itemName: Lamp
   itemImage: {fileID: -3535221090349844623, guid: 7ecc8f309a9f0ec4aba3879200ed0e6e, type: 3}
+  itemDataAsset: {fileID: 11400000, guid: 8b0ea114e6808ee4bb98dc56eb6c48c2, type: 2}
 --- !u!114 &7609228181890290987
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/MedicineItem.prefab
+++ b/Assets/Prefabs/MedicineItem.prefab
@@ -209,6 +209,7 @@ MonoBehaviour:
   itemType: 0
   itemName: Heal2
   itemImage: {fileID: 4475158985010180414, guid: a4d9ddf8d7e6b0146a1fdbc0159db0f4, type: 3}
+  itemDataAsset: {fileID: 11400000, guid: 83ac069170f18d34d9953b37b617dbfe, type: 2}
 --- !u!114 &-295572257772085249
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -174,6 +174,37 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
   m_PrefabInstance: {fileID: 1154744222}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &10501308 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1523823183359281106, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 635709930}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &10501309 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 635709930}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &10501310
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 10501308}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 365352cdfebfd0b4ba0d9fa7b3a29fa8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::EquipSlot
+  acceptedType: 1
+  itemIcon: {fileID: 930402103}
+  iconSize: {x: 64, y: 64}
+  equippedItem:
+    itemType: 0
+    itemName: 
+    itemImage: {fileID: 0}
+    count: 0
+    itemData: {fileID: 0}
 --- !u!1 &23362122
 GameObject:
   m_ObjectHideFlags: 0
@@ -249,6 +280,17 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 23362122}
   m_CullTransparentMesh: 1
+--- !u!114 &45804420 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3626232318315691473, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 519280201}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Text
 --- !u!224 &64193681 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
@@ -501,6 +543,17 @@ MonoBehaviour:
   m_EffectColor: {r: 0.29411766, g: 0.23921569, b: 0.26666668, a: 1}
   m_EffectDistance: {x: 1, y: 1}
   m_UseGraphicAlpha: 0
+--- !u!114 &140356131 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1197301866939096334, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 1223258275}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
 --- !u!1 &162169149
 GameObject:
   m_ObjectHideFlags: 0
@@ -548,6 +601,28 @@ Transform:
   - {fileID: 432061118}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &226850974 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1197301866939096334, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 774735956}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+--- !u!114 &243389764 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1197301866939096334, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 1897963884}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
 --- !u!1 &277665712
 GameObject:
   m_ObjectHideFlags: 0
@@ -766,6 +841,8 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1081348503}
+  - {fileID: 2142562031}
+  - {fileID: 1108392630}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -805,9 +882,41 @@ MonoBehaviour:
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
   slotHolder: {fileID: 524732905}
+--- !u!1 &324306656 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1523823183359281106, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 519280201}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &324306657 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 519280201}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &324306658
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 324306656}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6bdb2047e6c72c640a125b9eec68a868, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::QuickSlot
+  quickIndex: 0
+  itemIcon: {fileID: 1788431838}
+  itemCountText: {fileID: 45804420}
+  iconSize: {x: 64, y: 64}
+  linkedItem:
+    itemType: 0
+    itemName: 
+    itemImage: {fileID: 0}
+    count: 0
+    itemData: {fileID: 0}
+  linkedItemData: {fileID: 0}
+  linkedItemCount: 0
 --- !u!1 &350797384
 GameObject:
   m_ObjectHideFlags: 0
@@ -1087,6 +1196,40 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
   m_PrefabInstance: {fileID: 515643739}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &406603160 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1523823183359281106, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 1897963884}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &406603161 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 1897963884}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &406603162
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 406603160}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6bdb2047e6c72c640a125b9eec68a868, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::QuickSlot
+  quickIndex: 5
+  itemIcon: {fileID: 243389764}
+  itemCountText: {fileID: 2144813409}
+  iconSize: {x: 64, y: 64}
+  linkedItem:
+    itemType: 0
+    itemName: 
+    itemImage: {fileID: 0}
+    count: 0
+    itemData: {fileID: 0}
+  linkedItemData: {fileID: 0}
+  linkedItemCount: 0
 --- !u!1 &432061114
 GameObject:
   m_ObjectHideFlags: 0
@@ -1189,6 +1332,40 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1 &432606100 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1523823183359281106, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 1010209555}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &432606101 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 1010209555}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &432606102
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 432606100}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6bdb2047e6c72c640a125b9eec68a868, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::QuickSlot
+  quickIndex: 1
+  itemIcon: {fileID: 2090906253}
+  itemCountText: {fileID: 1264870901}
+  iconSize: {x: 64, y: 64}
+  linkedItem:
+    itemType: 0
+    itemName: 
+    itemImage: {fileID: 0}
+    count: 0
+    itemData: {fileID: 0}
+  linkedItemData: {fileID: 0}
+  linkedItemCount: 0
 --- !u!1 &437286909
 GameObject:
   m_ObjectHideFlags: 0
@@ -1265,6 +1442,17 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 437286909}
   m_CullTransparentMesh: 1
+--- !u!114 &453262032 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1197301866939096334, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 1693186285}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
 --- !u!224 &477014831 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
@@ -1544,6 +1732,109 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+--- !u!1001 &519280201
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1108392630}
+    m_Modifications:
+    - target: {fileID: 1523823183359281106, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Name
+      value: QuickSlot1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 300
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 3931838969198893435, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+    - {fileID: 4540717682764385154, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+    - {fileID: 9008203928857691915, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 1523823183359281106, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 324306658}
+  m_SourcePrefab: {fileID: 100100000, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
 --- !u!1 &519420028
 GameObject:
   m_ObjectHideFlags: 0
@@ -1697,6 +1988,17 @@ MonoBehaviour:
   target: {fileID: 1380755839}
   smoothSpeed: 0.1
   offset: {x: 0, y: 0, z: -10}
+--- !u!114 &521444573 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3626232318315691473, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 1938439593}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Text
 --- !u!1 &524732904
 GameObject:
   m_ObjectHideFlags: 0
@@ -1792,6 +2094,17 @@ MonoBehaviour:
   m_Spacing: {x: 20, y: 20}
   m_Constraint: 1
   m_ConstraintCount: 4
+--- !u!114 &541956189 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3626232318315691473, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 1693186285}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Text
 --- !u!1 &552625157
 GameObject:
   m_ObjectHideFlags: 0
@@ -76371,6 +76684,304 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 614482383}
   m_CullTransparentMesh: 1
+--- !u!1001 &635709930
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2142562031}
+    m_Modifications:
+    - target: {fileID: 1197301866939096334, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Color.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1197301866939096334, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Color.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1197301866939096334, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Color.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1523823183359281106, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Name
+      value: 'WeaponSlot '
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 160
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 160
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 220
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4540717682764385154, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: item.itemType
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4880298685924066059, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Color.a
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4880298685924066059, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_RaycastTarget
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6585454106428783490, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 6585454106428783490, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 64
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 4540717682764385154, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+    - {fileID: 3931838969198893435, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+    - {fileID: 9008203928857691915, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+    m_RemovedGameObjects:
+    - {fileID: 4710902861284076263, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 1523823183359281106, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 10501310}
+  m_SourcePrefab: {fileID: 100100000, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+--- !u!1 &644606065 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1523823183359281106, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 1693186285}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &644606066 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 1693186285}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &644606067
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 644606065}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6bdb2047e6c72c640a125b9eec68a868, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::QuickSlot
+  quickIndex: 3
+  itemIcon: {fileID: 453262032}
+  itemCountText: {fileID: 541956189}
+  iconSize: {x: 64, y: 64}
+  linkedItem:
+    itemType: 0
+    itemName: 
+    itemImage: {fileID: 0}
+    count: 0
+    itemData: {fileID: 0}
+  linkedItemData: {fileID: 0}
+  linkedItemCount: 0
+--- !u!1001 &646654365
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2142562031}
+    m_Modifications:
+    - target: {fileID: 1523823183359281106, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Name
+      value: ShoesSlot
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 160
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 160
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 350
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4540717682764385154, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: item.itemType
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4880298685924066059, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Color.a
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4880298685924066059, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_RaycastTarget
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6585454106428783490, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 6585454106428783490, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 64
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 4540717682764385154, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+    - {fileID: 3931838969198893435, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+    - {fileID: 9008203928857691915, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+    m_RemovedGameObjects:
+    - {fileID: 4710902861284076263, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 1523823183359281106, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1558906961}
+  m_SourcePrefab: {fileID: 100100000, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
 --- !u!1 &647549168
 GameObject:
   m_ObjectHideFlags: 0
@@ -76499,7 +77110,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 0.9333334, b: 0.5490196, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -76620,6 +77231,81 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+--- !u!1 &714748139
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 714748140}
+  - component: {fileID: 714748142}
+  - component: {fileID: 714748141}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &714748140
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 714748139}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2142562031}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -175}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &714748141
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 714748139}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 3516071402465835077, guid: 67c19f122a479fd4d849f14de6d271e6, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &714748142
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 714748139}
+  m_CullTransparentMesh: 1
 --- !u!1 &715778159
 GameObject:
   m_ObjectHideFlags: 0
@@ -76981,11 +77667,169 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+--- !u!1001 &774735956
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2142562031}
+    m_Modifications:
+    - target: {fileID: 1523823183359281106, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Name
+      value: LanternSlot
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 160
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 160
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 467.03183
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4540717682764385154, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: item.itemType
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4880298685924066059, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Color.a
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4880298685924066059, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_RaycastTarget
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6585454106428783490, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 6585454106428783490, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 64
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 4540717682764385154, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+    - {fileID: 3931838969198893435, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+    - {fileID: 9008203928857691915, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+    m_RemovedGameObjects:
+    - {fileID: 4710902861284076263, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 1523823183359281106, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2073632939}
+  m_SourcePrefab: {fileID: 100100000, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
 --- !u!224 &806991409 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
   m_PrefabInstance: {fileID: 702557180}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &850738100 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1523823183359281106, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 1223258275}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &850738101 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 1223258275}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &850738102
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 850738100}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6bdb2047e6c72c640a125b9eec68a868, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::QuickSlot
+  quickIndex: 2
+  itemIcon: {fileID: 140356131}
+  itemCountText: {fileID: 1142844858}
+  iconSize: {x: 64, y: 64}
+  linkedItem:
+    itemType: 0
+    itemName: 
+    itemImage: {fileID: 0}
+    count: 0
+    itemData: {fileID: 0}
+  linkedItemData: {fileID: 0}
+  linkedItemCount: 0
 --- !u!1 &884975781
 GameObject:
   m_ObjectHideFlags: 0
@@ -90580,6 +91424,17 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &930402103 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1197301866939096334, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 635709930}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
 --- !u!1 &935043365
 GameObject:
   m_ObjectHideFlags: 0
@@ -91336,6 +92191,109 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+--- !u!1001 &1010209555
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1108392630}
+    m_Modifications:
+    - target: {fileID: 1523823183359281106, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Name
+      value: QuickSlot2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 400
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 4540717682764385154, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+    - {fileID: 3931838969198893435, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+    - {fileID: 9008203928857691915, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 1523823183359281106, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 432606102}
+  m_SourcePrefab: {fileID: 100100000, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
 --- !u!1 &1011602200
 GameObject:
   m_ObjectHideFlags: 0
@@ -91504,6 +92462,87 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1081348502}
   m_CullTransparentMesh: 1
+--- !u!1 &1108392629
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1108392630}
+  - component: {fileID: 1108392632}
+  - component: {fileID: 1108392631}
+  m_Layer: 5
+  m_Name: QuickSlotPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1108392630
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1108392629}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 324306657}
+  - {fileID: 432606101}
+  - {fileID: 850738101}
+  - {fileID: 644606066}
+  - {fileID: 1512510979}
+  - {fileID: 406603161}
+  m_Father: {fileID: 289698062}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0.00012207031, y: -440.45996}
+  m_SizeDelta: {x: -756.935, y: -880.92}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1108392631
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1108392629}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1108392632
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1108392629}
+  m_CullTransparentMesh: 1
 --- !u!1 &1133050478
 GameObject:
   m_ObjectHideFlags: 0
@@ -91600,6 +92639,17 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1133050478}
   m_CullTransparentMesh: 1
+--- !u!114 &1142844858 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3626232318315691473, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 1223258275}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Text
 --- !u!1001 &1154744222
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -91897,10 +92947,13 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::InventoryManager
   QuickSlot:
-  - {fileID: 11400000, guid: 8b0ea114e6808ee4bb98dc56eb6c48c2, type: 2}
-  - {fileID: 11400000, guid: bb7ff0028a0fd97448e32d79d1f2f86c, type: 2}
-  - {fileID: 11400000, guid: c10bd0ec3aa35744a8ce875e9ac16e97, type: 2}
-  - {fileID: 11400000, guid: 43256f2a9282e59489a441e455b7cd72, type: 2}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  QuickSlotCounts: 000000000000000000000000000000000000000000000000
   HeroTransform: {fileID: 1380755839}
   HeroMoveControl: {fileID: 0}
 --- !u!4 &1215500393
@@ -92089,6 +93142,109 @@ PrefabInstance:
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+--- !u!1001 &1223258275
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1108392630}
+    m_Modifications:
+    - target: {fileID: 1523823183359281106, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Name
+      value: QuickSlot3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 500
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 4540717682764385154, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+    - {fileID: 3931838969198893435, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+    - {fileID: 9008203928857691915, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 1523823183359281106, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 850738102}
   m_SourcePrefab: {fileID: 100100000, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
 --- !u!1 &1227108192
 GameObject:
@@ -92387,6 +93543,17 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1263910625}
   m_CullTransparentMesh: 1
+--- !u!114 &1264870901 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3626232318315691473, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 1010209555}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Text
 --- !u!1 &1269302484
 GameObject:
   m_ObjectHideFlags: 0
@@ -92560,6 +93727,17 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+--- !u!114 &1308062637 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1197301866939096334, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 646654365}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
 --- !u!1 &1318826384
 GameObject:
   m_ObjectHideFlags: 0
@@ -92754,7 +93932,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1322584982
 RectTransform:
   m_ObjectHideFlags: 0
@@ -93901,6 +95079,17 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!114 &1510800354 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1197301866939096334, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 1938439593}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
 --- !u!1 &1511446958
 GameObject:
   m_ObjectHideFlags: 0
@@ -93977,6 +95166,40 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1511446958}
   m_CullTransparentMesh: 1
+--- !u!1 &1512510978 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1523823183359281106, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 1938439593}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &1512510979 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 1938439593}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1512510980
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1512510978}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6bdb2047e6c72c640a125b9eec68a868, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::QuickSlot
+  quickIndex: 4
+  itemIcon: {fileID: 1510800354}
+  itemCountText: {fileID: 521444573}
+  iconSize: {x: 64, y: 64}
+  linkedItem:
+    itemType: 0
+    itemName: 
+    itemImage: {fileID: 0}
+    count: 0
+    itemData: {fileID: 0}
+  linkedItemData: {fileID: 0}
+  linkedItemCount: 0
 --- !u!1001 &1532206701
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -94074,6 +95297,112 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+--- !u!1 &1555551234
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1555551235}
+  - component: {fileID: 1555551237}
+  - component: {fileID: 1555551236}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1555551235
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1555551234}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2142562031}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -1.9226074, y: -45}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1555551236
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1555551234}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 3516071402465835077, guid: 67c19f122a479fd4d849f14de6d271e6, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1555551237
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1555551234}
+  m_CullTransparentMesh: 1
+--- !u!1 &1558906959 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1523823183359281106, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 646654365}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &1558906960 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 646654365}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1558906961
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1558906959}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 365352cdfebfd0b4ba0d9fa7b3a29fa8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::EquipSlot
+  acceptedType: 0
+  itemIcon: {fileID: 1308062637}
+  iconSize: {x: 64, y: 64}
+  equippedItem:
+    itemType: 0
+    itemName: 
+    itemImage: {fileID: 0}
+    count: 0
+    itemData: {fileID: 0}
 --- !u!224 &1562463208 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
@@ -94259,6 +95588,109 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
   m_PrefabInstance: {fileID: 2095771566}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1693186285
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1108392630}
+    m_Modifications:
+    - target: {fileID: 1523823183359281106, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Name
+      value: QuickSlot4
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 600
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 4540717682764385154, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+    - {fileID: 3931838969198893435, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+    - {fileID: 9008203928857691915, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 1523823183359281106, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 644606067}
+  m_SourcePrefab: {fileID: 100100000, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
 --- !u!1 &1714470626
 GameObject:
   m_ObjectHideFlags: 0
@@ -94593,6 +96025,17 @@ MonoBehaviour:
   dialogueText: {fileID: 935043367}
   choicesParent: {fileID: 1227108193}
   choiceButtonPrefab: {fileID: 1298622577912982735, guid: c2d9dfc01a2944d0d80cd9fcc5bd3fc8, type: 3}
+--- !u!114 &1788431838 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1197301866939096334, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 519280201}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
 --- !u!1 &1838423526
 GameObject:
   m_ObjectHideFlags: 0
@@ -94636,7 +96079,7 @@ Transform:
   m_GameObject: {fileID: 1838423526}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 3.86125, y: -2.15774, z: 0}
+  m_LocalPosition: {x: 3566, y: -2.15774, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -94935,6 +96378,184 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: -14, y: 11.5}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1891443325
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1891443326}
+  - component: {fileID: 1891443328}
+  - component: {fileID: 1891443327}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1891443326
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1891443325}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2142562031}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 74}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1891443327
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1891443325}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 3516071402465835077, guid: 67c19f122a479fd4d849f14de6d271e6, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1891443328
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1891443325}
+  m_CullTransparentMesh: 1
+--- !u!1001 &1897963884
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1108392630}
+    m_Modifications:
+    - target: {fileID: 1523823183359281106, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Name
+      value: QuickSlot6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 800
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 4540717682764385154, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+    - {fileID: 3931838969198893435, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+    - {fileID: 9008203928857691915, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 1523823183359281106, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 406603162}
+  m_SourcePrefab: {fileID: 100100000, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
 --- !u!1 &1897992919
 GameObject:
   m_ObjectHideFlags: 0
@@ -95089,6 +96710,109 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1907863210}
   m_CullTransparentMesh: 1
+--- !u!1001 &1938439593
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1108392630}
+    m_Modifications:
+    - target: {fileID: 1523823183359281106, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Name
+      value: QuickSlot5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 700
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 4540717682764385154, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+    - {fileID: 3931838969198893435, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+    - {fileID: 9008203928857691915, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 1523823183359281106, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1512510980}
+  m_SourcePrefab: {fileID: 100100000, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
 --- !u!1001 &1976465383
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -95600,6 +97324,48 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
   m_PrefabInstance: {fileID: 1532206701}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &2073632930 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1523823183359281106, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 774735956}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &2073632931 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 774735956}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2073632939
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2073632930}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 365352cdfebfd0b4ba0d9fa7b3a29fa8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::EquipSlot
+  acceptedType: 2
+  itemIcon: {fileID: 226850974}
+  iconSize: {x: 64, y: 64}
+  equippedItem:
+    itemType: 0
+    itemName: 
+    itemImage: {fileID: 0}
+    count: 0
+    itemData: {fileID: 0}
+--- !u!114 &2090906253 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1197301866939096334, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 1010209555}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
 --- !u!1001 &2095771566
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -95881,6 +97647,98 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
   m_PrefabInstance: {fileID: 971288459}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &2142562030
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2142562031}
+  - component: {fileID: 2142562033}
+  - component: {fileID: 2142562032}
+  m_Layer: 5
+  m_Name: EquipPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2142562031
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2142562030}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1891443326}
+  - {fileID: 1555551235}
+  - {fileID: 714748140}
+  - {fileID: 2073632931}
+  - {fileID: 1558906960}
+  - {fileID: 10501309}
+  m_Father: {fileID: 289698062}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -858.0774, y: -145}
+  m_SizeDelta: {x: -1716.1548, y: -290}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2142562032
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2142562030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.49803922, g: 0.49803922, b: 0.49803922, a: 0}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &2142562033
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2142562030}
+  m_CullTransparentMesh: 1
+--- !u!114 &2144813409 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3626232318315691473, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+  m_PrefabInstance: {fileID: 1897963884}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Text
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -917,6 +917,7 @@ MonoBehaviour:
     itemData: {fileID: 0}
   linkedItemData: {fileID: 0}
   linkedItemCount: 0
+  linkedInventoryIndex: -1
 --- !u!1 &350797384
 GameObject:
   m_ObjectHideFlags: 0
@@ -1230,6 +1231,7 @@ MonoBehaviour:
     itemData: {fileID: 0}
   linkedItemData: {fileID: 0}
   linkedItemCount: 0
+  linkedInventoryIndex: -1
 --- !u!1 &432061114
 GameObject:
   m_ObjectHideFlags: 0
@@ -1366,6 +1368,7 @@ MonoBehaviour:
     itemData: {fileID: 0}
   linkedItemData: {fileID: 0}
   linkedItemCount: 0
+  linkedInventoryIndex: -1
 --- !u!1 &437286909
 GameObject:
   m_ObjectHideFlags: 0
@@ -2047,8 +2050,6 @@ RectTransform:
   - {fileID: 2139607309}
   - {fileID: 2116165126}
   - {fileID: 2071541180}
-  - {fileID: 1622290378}
-  - {fileID: 1987247082}
   m_Father: {fileID: 1263910626}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
@@ -2093,7 +2094,7 @@ MonoBehaviour:
   m_CellSize: {x: 160, y: 160}
   m_Spacing: {x: 20, y: 20}
   m_Constraint: 1
-  m_ConstraintCount: 4
+  m_ConstraintCount: 3
 --- !u!114 &541956189 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3626232318315691473, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
@@ -76858,6 +76859,7 @@ MonoBehaviour:
     itemData: {fileID: 0}
   linkedItemData: {fileID: 0}
   linkedItemCount: 0
+  linkedInventoryIndex: -1
 --- !u!1001 &646654365
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -77570,103 +77572,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 739866195}
   m_CullTransparentMesh: 1
---- !u!1001 &743285542
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 524732905}
-    m_Modifications:
-    - target: {fileID: 1523823183359281106, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_Name
-      value: Slot (19)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
 --- !u!1001 &774735956
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -77830,6 +77735,7 @@ MonoBehaviour:
     itemData: {fileID: 0}
   linkedItemData: {fileID: 0}
   linkedItemCount: 0
+  linkedInventoryIndex: -1
 --- !u!1 &884975781
 GameObject:
   m_ObjectHideFlags: 0
@@ -91604,103 +91510,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 0
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!1001 &946844805
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 524732905}
-    m_Modifications:
-    - target: {fileID: 1523823183359281106, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_Name
-      value: Slot (18)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
 --- !u!1 &947451262
 GameObject:
   m_ObjectHideFlags: 0
@@ -92406,8 +92215,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 450, y: 0}
-  m_SizeDelta: {x: 800, y: 500}
+  m_AnchoredPosition: {x: 600, y: 10}
+  m_SizeDelta: {x: 600, y: 700}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1081348504
 MonoBehaviour:
@@ -92502,7 +92311,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0.00012207031, y: -440.45996}
+  m_AnchoredPosition: {x: 0, y: -440.45996}
   m_SizeDelta: {x: -756.935, y: -880.92}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1108392631
@@ -92946,14 +92755,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f135c7e5dba85dd4c94e3dbd160fd08d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::InventoryManager
-  QuickSlot:
+  quickSlotItems:
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}
-  QuickSlotCounts: 000000000000000000000000000000000000000000000000
+  quickSlotCounts: 000000000000000000000000000000000000000000000000
+  quickSlotInventoryIndices: 000000000000000000000000000000000000000000000000
   HeroTransform: {fileID: 1380755839}
   HeroMoveControl: {fileID: 0}
 --- !u!4 &1215500393
@@ -95200,6 +95010,7 @@ MonoBehaviour:
     itemData: {fileID: 0}
   linkedItemData: {fileID: 0}
   linkedItemCount: 0
+  linkedInventoryIndex: -1
 --- !u!1001 &1532206701
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -95491,11 +95302,6 @@ Transform:
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
   m_PrefabInstance: {fileID: 999143080}
-  m_PrefabAsset: {fileID: 0}
---- !u!224 &1622290378 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-  m_PrefabInstance: {fileID: 946844805}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1660647209
 GameObject:
@@ -96870,11 +96676,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 28cdfd04d11c08640a2611f883f9372c, type: 3}
---- !u!224 &1987247082 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-  m_PrefabInstance: {fileID: 743285542}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1988239604
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/HeroItemUse.cs
+++ b/Assets/Scripts/HeroItemUse.cs
@@ -48,29 +48,56 @@ public class HeroItemUse : MonoBehaviour
     {
         if (context.performed)
         {
-            selectedItem = InventoryManager.Instance.selectItem(1);
+            UseQuickSlot(1);
         }
     }
     public void OnQuickSlot2(InputAction.CallbackContext context)
     {
         if (context.performed)
         {
-            selectedItem = InventoryManager.Instance.selectItem(2);
+            UseQuickSlot(2);
         }
     }
     public void OnQuickSlot3(InputAction.CallbackContext context)
     {
         if (context.performed)
         {
-            selectedItem = InventoryManager.Instance.selectItem(3);
+            UseQuickSlot(3);
         }
     }
     public void OnQuickSlot4(InputAction.CallbackContext context)
     {
         if (context.performed)
         {
-            selectedItem = InventoryManager.Instance.selectItem(4);
+            UseQuickSlot(4);
         }
+    }
+
+    public void OnQuickSlot5(InputAction.CallbackContext context)
+    {
+        if (context.performed)
+        {
+            UseQuickSlot(5);
+        }
+    }
+
+    public void OnQuickSlot6(InputAction.CallbackContext context)
+    {
+        if (context.performed)
+        {
+            UseQuickSlot(6);
+        }
+    }
+
+    private void UseQuickSlot(int slotNumber)
+    {
+        if (InventoryManager.Instance == null)
+        {
+            Debug.LogWarning("InventoryManager 인스턴스를 찾을 수 없습니다.");
+            return;
+        }
+
+        InventoryManager.Instance.useQuickSlotItem(slotNumber);
     }
 
     // 실시간 마우스 위치를 얻어와서 해당 위치에 ui가 있는지 확인하기 위함.

--- a/Assets/Scripts/Inven/EquipSlot.cs
+++ b/Assets/Scripts/Inven/EquipSlot.cs
@@ -72,6 +72,9 @@ public class EquipSlot : MonoBehaviour
         allSlots.Remove(this);
     }
 
+    /// <summary>
+    /// 현재 포인터 위치에 있는 장비 슬롯을 찾아 드래그 시 사용합니다.
+    /// </summary>
     public static EquipSlot FindSlotUnderPointer(Vector2 screenPos, Camera uiCamera)
     {
         for (int i = 0; i < allSlots.Count; i++)
@@ -101,6 +104,9 @@ public class EquipSlot : MonoBehaviour
         return null;
     }
 
+    /// <summary>
+    /// 장착된 아이템의 스프라이트를 슬롯 아이콘에 반영합니다.
+    /// </summary>
     private void ApplyIcon(Sprite sprite)
     {
         if (itemIcon == null || sprite == null) return;
@@ -178,11 +184,6 @@ public class EquipSlot : MonoBehaviour
                 Debug.Log($"[EquipSlot] 인벤토리 {idx}번 슬롯 아이템 제거 완료.", this);
             }
         }
-
-        // 이후에 필요하면:
-        // - Inventory.instance 에 equippedWeapon / equippedLantern 같은 필드를 두고
-        //   여기서 그 값도 함께 세팅
-        // - 장착/해제 시 캐릭터 능력치 갱신 등 추가 가능
     }
 }
 

--- a/Assets/Scripts/Inven/EquipSlot.cs
+++ b/Assets/Scripts/Inven/EquipSlot.cs
@@ -1,0 +1,189 @@
+using UnityEngine;
+using UnityEngine.UI;
+using UnityEngine.EventSystems;
+
+/// <summary>
+/// 장비 슬롯 (LanternSlot, ShoesSlot, WeaponSlot)에 붙일 스크립트.
+/// 인벤토리 슬롯(ScrollView 안의 Content 하위 슬롯)에서 드래그한 아이템을
+/// 타입에 맞게 받아와서 아이콘만 표시하는 기본 구조입니다.
+/// </summary>
+public class EquipSlot : MonoBehaviour
+{
+    [Header("이 슬롯이 받을 수 있는 아이템 타입")]
+    public ItemView acceptedType;        // 예: Lantern, Weapon 등
+
+    [Header("UI 참조")]
+    public Image itemIcon;              // 장착된 아이템 아이콘 (비워두면 자동으로 Slot.itemIcon 사용)
+
+    [Header("아이콘 표시 설정")]
+    [SerializeField] private Vector2 iconSize = new Vector2(64f, 64f);
+
+    [HideInInspector]
+    public InventoryItem equippedItem;  // 현재 장착된 아이템 데이터
+
+    private static readonly System.Collections.Generic.List<EquipSlot> allSlots
+        = new System.Collections.Generic.List<EquipSlot>();
+
+    private void TryAutoAssignItemIcon()
+    {
+        // 1) 인스펙터에서 비워둔 경우, 같은 오브젝트의 Slot 컴포넌트에서 시도
+        if (itemIcon == null)
+        {
+            Slot slot = GetComponent<Slot>();
+            if (slot != null && slot.itemIcon != null)
+            {
+                itemIcon = slot.itemIcon;
+            }
+        }
+
+        // 2) 그래도 null이면, 자식 중 첫 번째 Image 를 자동으로 사용 (주로 ItemImage)
+        if (itemIcon == null)
+        {
+            Image[] images = GetComponentsInChildren<Image>(true);
+            foreach (var img in images)
+            {
+                if (img.gameObject != this.gameObject)
+                {
+                    itemIcon = img;
+                    break;
+                }
+            }
+        }
+    }
+
+    private void Awake()
+    {
+        if (!allSlots.Contains(this))
+            allSlots.Add(this);
+
+        // 자동 할당 시도
+        TryAutoAssignItemIcon();
+
+        // 장착 전에는 아이콘 숨김
+        if (itemIcon != null)
+        {
+            itemIcon.gameObject.SetActive(false);
+            itemIcon.raycastTarget = false;   // 장비 아이콘은 드래그 대상이 아니라 표시 전용
+        }
+    }
+
+    private void OnDestroy()
+    {
+        allSlots.Remove(this);
+    }
+
+    public static EquipSlot FindSlotUnderPointer(Vector2 screenPos, Camera uiCamera)
+    {
+        for (int i = 0; i < allSlots.Count; i++)
+        {
+            var slot = allSlots[i];
+            if (slot == null || !slot.gameObject.activeInHierarchy) continue;
+
+            // 1) 슬롯 자체 Rect 검사
+            RectTransform slotRect = slot.transform as RectTransform;
+            if (slotRect != null && slotRect.rect.size.sqrMagnitude > 0f &&
+                RectTransformUtility.RectangleContainsScreenPoint(slotRect, screenPos, uiCamera))
+            {
+                return slot;
+            }
+
+            // 2) 아이콘 Rect 검사 (슬롯 Rect 크기가 0인 경우 대비)
+            if (slot.itemIcon != null)
+            {
+                RectTransform iconRect = slot.itemIcon.rectTransform;
+                if (iconRect != null &&
+                    RectTransformUtility.RectangleContainsScreenPoint(iconRect, screenPos, uiCamera))
+                {
+                    return slot;
+                }
+            }
+        }
+        return null;
+    }
+
+    private void ApplyIcon(Sprite sprite)
+    {
+        if (itemIcon == null || sprite == null) return;
+
+        itemIcon.sprite = sprite;
+        itemIcon.gameObject.SetActive(true);
+
+        RectTransform iconRect = itemIcon.rectTransform;
+        iconRect.anchorMin = new Vector2(0.5f, 0.5f);
+        iconRect.anchorMax = new Vector2(0.5f, 0.5f);
+        iconRect.pivot = new Vector2(0.5f, 0.5f);
+        iconRect.anchoredPosition = Vector2.zero;
+        iconRect.sizeDelta = iconSize;
+
+        itemIcon.preserveAspect = true;
+        itemIcon.transform.SetAsLastSibling();    // 배경보다 위에 표시
+        // 슬롯 자체보다도 항상 앞에 오도록 보장
+        var slotRect = transform as RectTransform;
+        if (slotRect != null && itemIcon.transform.GetSiblingIndex() <= slotRect.GetSiblingIndex())
+        {
+            itemIcon.transform.SetSiblingIndex(slotRect.GetSiblingIndex() + 1);
+        }
+    }
+
+    /// <summary>
+    /// 인벤토리의 Slot에서 끌어온 아이템을 이 장비 슬롯에 장착시키는 함수.
+    /// Drag 끝났을 때 ItemDragHandler 에서 직접 호출한다.
+    /// </summary>
+    public void EquipFromSlot(Slot fromSlot)
+    {
+        // 드래그 시작한 쪽은 인벤토리의 Slot 이어야 함
+        if (fromSlot == null)
+        {
+            Debug.LogWarning("[EquipSlot] EquipFromSlot: fromSlot 이 null 입니다.", this);
+            return;
+        }
+        if (fromSlot.item == null)
+        {
+            Debug.LogWarning("[EquipSlot] EquipFromSlot: fromSlot.item 이 null 입니다. (비어있는 슬롯에서 드래그)", this);
+            return;
+        }
+
+        InventoryItem fromItem = fromSlot.item;
+        Debug.Log($"[EquipSlot] EquipFromSlot 호출됨. 아이템: {fromItem.itemName}, 타입: {fromItem.itemType}", this);
+
+        // 타입이 맞는 아이템만 장착
+        if (fromItem.itemType != acceptedType)
+        {
+            Debug.LogWarning($"[EquipSlot] EquipFromSlot: 타입 불일치. 이 슬롯: {acceptedType}, 아이템 타입: {fromItem.itemType}", this);
+            return;
+        }
+
+        // 일단은 "복사해서 장착" 개념으로, 인벤토리 쪽 수량 변화는 아직 건드리지 않음.
+        equippedItem = fromItem;
+
+        if (itemIcon != null)
+        {
+            ApplyIcon(fromItem.itemImage);
+            Debug.Log("[EquipSlot] 아이콘 세팅 완료.", this);
+        }
+        else
+        {
+            Debug.LogWarning("[EquipSlot] itemIcon 이 null 입니다. 인스펙터에서 Item Icon 을 연결했는지 확인하세요.", this);
+        }
+
+        // 인벤토리 슬롯에서 아이템 제거 (이동 느낌 나게)
+        Inventory inven = Inventory.instance;
+        if (inven != null)
+        {
+            int idx = fromSlot.slotIndex;
+            if (idx >= 0 && idx < inven.items.Count)
+            {
+                inven.items[idx] = null;
+                inven.onChangeItem?.Invoke();   // 인벤 UI 다시 그리기
+                Debug.Log($"[EquipSlot] 인벤토리 {idx}번 슬롯 아이템 제거 완료.", this);
+            }
+        }
+
+        // 이후에 필요하면:
+        // - Inventory.instance 에 equippedWeapon / equippedLantern 같은 필드를 두고
+        //   여기서 그 값도 함께 세팅
+        // - 장착/해제 시 캐릭터 능력치 갱신 등 추가 가능
+    }
+}
+
+

--- a/Assets/Scripts/Inven/EquipSlot.cs.meta
+++ b/Assets/Scripts/Inven/EquipSlot.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 365352cdfebfd0b4ba0d9fa7b3a29fa8

--- a/Assets/Scripts/Inven/FieldItems.cs
+++ b/Assets/Scripts/Inven/FieldItems.cs
@@ -1,5 +1,8 @@
 using UnityEngine;
 
+/// <summary>
+/// 필드에 떨어진 아이템과 개수를 보관하고 플레이어가 주웠을 때 제거를 담당합니다.
+/// </summary>
 public class FieldItems : MonoBehaviour
 {
     private Item item;
@@ -10,22 +13,34 @@ public class FieldItems : MonoBehaviour
         if (item == null)
             item = GetComponent<Item>();   // ★ 자동 연결
     }
+    /// <summary>
+    /// 드랍 정보를 외부에서 지정할 때 사용하며 아이템과 개수를 동기화합니다.
+    /// </summary>
     public void SetItem(Item newItem, int newCount = 1)
     {
         item = newItem;
         count = newCount;
     }
 
+    /// <summary>
+    /// 현재 필드 아이템 데이터를 반환합니다.
+    /// </summary>
     public Item GetItem()
     {
         return item;
     }
 
+    /// <summary>
+    /// 쌓여 있는 아이템 개수를 반환합니다.
+    /// </summary>
     public int GetCount()
     {
         return count;
     }
 
+    /// <summary>
+    /// 필드 오브젝트를 제거해 재사용되지 않도록 합니다.
+    /// </summary>
     public void DestroyItem()
     {
         Destroy(gameObject);

--- a/Assets/Scripts/Inven/Inventory.cs
+++ b/Assets/Scripts/Inven/Inventory.cs
@@ -1,6 +1,9 @@
 using UnityEngine;
 using System.Collections.Generic;
 
+/// <summary>
+/// 인벤토리 슬롯 리스트를 유지하며 아이템 추가/소비 이벤트를 브로드캐스트합니다.
+/// </summary>
 public class Inventory : MonoBehaviour
 {
     #region Singleton
@@ -28,6 +31,9 @@ public class Inventory : MonoBehaviour
 
     public int slotCnt = 20;
 
+    /// <summary>
+    /// 필드 아이템 데이터를 받아 슬롯에 추가하거나 기존 스택을 증가시킵니다.
+    /// </summary>
     public bool AddItem(Item worldItem, int addCount = 1)
     {
         if (worldItem == null) return false;
@@ -60,6 +66,9 @@ public class Inventory : MonoBehaviour
         return true;
     }
 
+    /// <summary>
+    /// 지정 슬롯에서 개수를 차감하고 0 이하일 경우 슬롯을 비웁니다.
+    /// </summary>
     public int ConsumeItemAt(int index, int amount = 1)
     {
         if (index < 0 || index >= items.Count) return 0;

--- a/Assets/Scripts/Inven/Inventory.cs
+++ b/Assets/Scripts/Inven/Inventory.cs
@@ -32,8 +32,8 @@ public class Inventory : MonoBehaviour
     {
         if (worldItem == null) return false;
 
-        // 이미 존재하는 아이템이면 count 증가
-        int idx = items.FindIndex(i => i.itemName == worldItem.itemName);
+        // 이미 존재하는 아이템이면 count 증가 (null 슬롯 방지)
+        int idx = items.FindIndex(i => i != null && i.itemName == worldItem.itemName);
         if (idx != -1)
         {
             items[idx].count += addCount;
@@ -43,7 +43,18 @@ public class Inventory : MonoBehaviour
 
         // 새 슬롯에 추가
         InventoryItem newItem = new InventoryItem(worldItem, addCount);
-        items.Add(newItem);
+
+        // 먼저 비어있는 슬롯(null)을 재사용
+        int emptyIdx = items.FindIndex(i => i == null);
+        if (emptyIdx != -1)
+        {
+            items[emptyIdx] = newItem;
+        }
+        else
+        {
+            // 공간이 모자라면 리스트 확장 (slotCnt 제한은 UI에서 처리)
+            items.Add(newItem);
+        }
 
         onChangeItem?.Invoke();
         return true;

--- a/Assets/Scripts/Inven/Inventory.cs
+++ b/Assets/Scripts/Inven/Inventory.cs
@@ -59,4 +59,21 @@ public class Inventory : MonoBehaviour
         onChangeItem?.Invoke();
         return true;
     }
+
+    public int ConsumeItemAt(int index, int amount = 1)
+    {
+        if (index < 0 || index >= items.Count) return 0;
+        var item = items[index];
+        if (item == null) return 0;
+
+        item.count -= amount;
+        if (item.count <= 0)
+        {
+            items[index] = null;
+            item.count = 0;
+        }
+
+        onChangeItem?.Invoke();
+        return item != null ? item.count : 0;
+    }
 }

--- a/Assets/Scripts/Inven/InventoryItem.cs
+++ b/Assets/Scripts/Inven/InventoryItem.cs
@@ -1,6 +1,9 @@
 using UnityEngine;
 
 [System.Serializable]
+/// <summary>
+/// 인벤토리 슬롯이 참조하는 단일 아이템 스택(이름, 아이콘, 데이터 포함)입니다.
+/// </summary>
 public class InventoryItem
 {
     public ItemView itemType;
@@ -9,6 +12,9 @@ public class InventoryItem
     public int count;
     public ItemData itemData;
 
+    /// <summary>
+    /// 필드 아이템 정보를 복사해 인벤토리 표현용 데이터로 변환합니다.
+    /// </summary>
     public InventoryItem(Item src, int count)
     {
         this.itemType = src.itemType;

--- a/Assets/Scripts/Inven/InventoryItem.cs
+++ b/Assets/Scripts/Inven/InventoryItem.cs
@@ -7,6 +7,7 @@ public class InventoryItem
     public string itemName;
     public Sprite itemImage;
     public int count;
+    public ItemData itemData;
 
     public InventoryItem(Item src, int count)
     {
@@ -14,5 +15,6 @@ public class InventoryItem
         this.itemName = src.itemName;
         this.itemImage = src.itemImage;
         this.count = count;
+        this.itemData = src.itemDataAsset;
     }
 }

--- a/Assets/Scripts/Inven/InventoryUI.cs
+++ b/Assets/Scripts/Inven/InventoryUI.cs
@@ -2,6 +2,9 @@ using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.UI;
 
+/// <summary>
+/// 인벤토리 패널 열기/닫기와 슬롯 UI 갱신을 담당하는 프리젠테이션 계층입니다.
+/// </summary>
 public class InventoryUI : MonoBehaviour
 {
     Inventory inven;
@@ -33,6 +36,9 @@ public class InventoryUI : MonoBehaviour
     }
 
     // 슬롯 개수와 관계없이 항상 전부 활성화
+    /// <summary>
+    /// 슬롯 개수 변경 이벤트를 받아 모든 슬롯을 활성화합니다.
+    /// </summary>
     private void SlotChange(int val)
     {
         for (int i = 0; i < slots.Length; i++)
@@ -50,6 +56,9 @@ public class InventoryUI : MonoBehaviour
         }
     }
 
+    /// <summary>
+    /// 외부 버튼에서 호출돼 슬롯 수를 늘리고 UI를 갱신합니다.
+    /// </summary>
     public void AddSlot()
     {
         // 슬롯 제한 안 쓸 거면 사실상 의미 없지만, 일단 맞춰줌
@@ -57,6 +66,9 @@ public class InventoryUI : MonoBehaviour
         SlotChange(slots.Length);
     }
 
+    /// <summary>
+    /// 인벤토리 데이터와 UI 슬롯 간 내용을 동기화합니다.
+    /// </summary>
     void RedrawSlotUI()
     {
         // 모든 슬롯 초기화

--- a/Assets/Scripts/Inven/Item.cs
+++ b/Assets/Scripts/Inven/Item.cs
@@ -1,5 +1,8 @@
 using UnityEngine;
 
+/// <summary>
+/// UI와 장비 슬롯에서 구분하기 위한 아이템 카테고리입니다.
+/// </summary>
 public enum ItemView
 {
     Heal,
@@ -9,6 +12,9 @@ public enum ItemView
 }
 
 [System.Serializable]
+/// <summary>
+/// 필드 오브젝트가 보유하는 기본 아이템 정보 및 사용 로직의 뼈대입니다.
+/// </summary>
 public class Item : MonoBehaviour
 {
     public ItemView itemType;

--- a/Assets/Scripts/Inven/Item.cs
+++ b/Assets/Scripts/Inven/Item.cs
@@ -15,6 +15,9 @@ public class Item : MonoBehaviour
     public string itemName;
     public Sprite itemImage;
 
+    [Header("퀵슬롯/사용 데이터 (선택)")]
+    public ItemData itemDataAsset;
+
     public virtual bool Use()
     {
         return false;

--- a/Assets/Scripts/Inven/ItemDatabase.cs
+++ b/Assets/Scripts/Inven/ItemDatabase.cs
@@ -1,6 +1,9 @@
 using System.Collections.Generic;
 using UnityEngine;
 
+/// <summary>
+/// 등록된 아이템 프리팹에서 Item 정보를 읽어 런타임 DB를 구성합니다.
+/// </summary>
 public class ItemDatabase : MonoBehaviour
 {
     public static ItemDatabase instance;   // DB를 어디서든 접근하기 위한 싱글톤
@@ -21,7 +24,9 @@ public class ItemDatabase : MonoBehaviour
         LoadItemsFromPrefabs();            // 프리팹에서 아이템 데이터 자동 로드
     }
 
-    // 프리팹에서 Item 컴포넌트 정보를 가져와 DB에 등록하는 함수
+    /// <summary>
+    /// 인스펙터에 등록된 프리팹을 순회하며 Item 데이터를 캐싱합니다.
+    /// </summary>
     void LoadItemsFromPrefabs()
     {
         itemDB.Clear();                    // 기존 DB 초기화

--- a/Assets/Scripts/Inven/ItemDragHandler.cs
+++ b/Assets/Scripts/Inven/ItemDragHandler.cs
@@ -27,21 +27,44 @@ public class ItemDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler, I
             slot = GetComponentInParent<Slot>();
             if (slot == null)
             {
-                Debug.LogError("[ItemDragHandler] 부모에 Slot 컴포넌트가 없습니다.", this);
+                // 인벤토리 슬롯이 아닌 곳에 잘못 붙어 있는 경우를 대비한 방어 코드
+                // 에러를 계속 뿜지 않고, 이 컴포넌트를 비활성화해서 드래그가 동작하지 않게만 한다.
+                Debug.LogWarning("[ItemDragHandler.Awake] 부모에 Slot 컴포넌트가 없어 ItemDragHandler를 비활성화합니다. 객체: " + name, this);
+                enabled = false;
+                return;
+            } else {
+                Debug.Log("[ItemDragHandler.Awake] Slot 컴포넌트 발견: " + slot.name, this);
             }
         }
 
         canvas = GetComponentInParent<Canvas>();
         if (canvas == null)
         {
-            Debug.LogError("[ItemDragHandler] 상위에 Canvas가 없습니다.", this);
+            Debug.LogError("[ItemDragHandler.Awake] 상위에 Canvas가 없습니다.", this);
+        } else {
+            Debug.Log("[ItemDragHandler.Awake] Canvas 컴포넌트 발견: " + canvas.name, this);
         }
+
     }
 
     public void OnBeginDrag(PointerEventData eventData)
     {
-        if (slot == null || canvas == null) return;
-        if (slot.item == null) return; // ★ InventoryItem 기준
+        Debug.Log("OnBeginDrag 호출됨. 드래그하려는 객체: " + gameObject.name);
+        if (slot == null)
+        {
+            Debug.LogWarning("OnBeginDrag: slot이 null이어서 드래그를 시작할 수 없습니다. 객체: " + gameObject.name);
+            return;
+        }
+        if (canvas == null)
+        {
+            Debug.LogWarning("OnBeginDrag: canvas가 null이어서 드래그를 시작할 수 없습니다. 객체: " + gameObject.name);
+            return;
+        }
+        if (slot.item == null) // ★ InventoryItem 기준
+        {
+            Debug.LogWarning("OnBeginDrag: slot.item이 null이어서 드래그를 시작할 수 없습니다. (슬롯이 비어있음) 객체: " + gameObject.name);
+            return;
+        }
 
         currentlyDragging = this;
 
@@ -65,6 +88,31 @@ public class ItemDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler, I
 
         canvasGroup.blocksRaycasts = true;
 
+        Vector2 pointerPos = eventData != null ? eventData.position : (Vector2)Input.mousePosition;
+        Camera uiCamera = canvas != null && canvas.renderMode != RenderMode.ScreenSpaceOverlay
+            ? canvas.worldCamera
+            : null;
+
+        bool handled = false;
+
+        // 장비 슬롯 검사
+        EquipSlot equipSlot = EquipSlot.FindSlotUnderPointer(pointerPos, uiCamera);
+        if (equipSlot != null)
+        {
+            equipSlot.EquipFromSlot(slot);
+            handled = true;
+        }
+
+        if (!handled)
+        {
+            QuickSlot quickSlot = QuickSlot.FindSlotUnderPointer(pointerPos, uiCamera);
+            if (quickSlot != null)
+            {
+                quickSlot.AssignFromSlot(slot);
+            }
+        }
+
+        // 아이콘 원래 자리로 복귀 (실제 데이터는 Slot/EquipSlot/QuickSlot 이 관리)
         transform.SetParent(originalParent, true);
         rectTransform.anchoredPosition = originalPos;
 

--- a/Assets/Scripts/Inven/ItemDragHandler.cs
+++ b/Assets/Scripts/Inven/ItemDragHandler.cs
@@ -2,6 +2,9 @@ using UnityEngine;
 using UnityEngine.EventSystems;
 
 [RequireComponent(typeof(RectTransform))]
+/// <summary>
+/// 인벤토리 슬롯 아이콘을 드래그하여 다른 슬롯/장비/퀵슬롯으로 옮기는 입력 처리기입니다.
+/// </summary>
 public class ItemDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHandler
 {
     public static ItemDragHandler currentlyDragging;
@@ -47,6 +50,9 @@ public class ItemDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler, I
 
     }
 
+    /// <summary>
+    /// 드래그를 시작하며 캔버스로 이동시키고 레이캐스트를 비활성화합니다.
+    /// </summary>
     public void OnBeginDrag(PointerEventData eventData)
     {
         Debug.Log("OnBeginDrag 호출됨. 드래그하려는 객체: " + gameObject.name);
@@ -75,6 +81,9 @@ public class ItemDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler, I
         canvasGroup.blocksRaycasts = false;
     }
 
+    /// <summary>
+    /// 마우스 이동량을 따라다니도록 아이콘 위치를 업데이트합니다.
+    /// </summary>
     public void OnDrag(PointerEventData eventData)
     {
         if (currentlyDragging != this || canvas == null) return;
@@ -82,6 +91,9 @@ public class ItemDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler, I
         rectTransform.anchoredPosition += eventData.delta / canvas.scaleFactor;
     }
 
+    /// <summary>
+    /// 드래그 종료 시 장비/퀵슬롯 할당을 시도하고 아이콘을 되돌립니다.
+    /// </summary>
     public void OnEndDrag(PointerEventData eventData)
     {
         if (currentlyDragging != this) return;

--- a/Assets/Scripts/Inven/QuickSlot.cs
+++ b/Assets/Scripts/Inven/QuickSlot.cs
@@ -25,6 +25,8 @@ public class QuickSlot : MonoBehaviour
     public ItemData linkedItemData;
     [HideInInspector]
     public int linkedItemCount;
+    [HideInInspector]
+    public int linkedInventoryIndex = -1;
 
     private static readonly System.Collections.Generic.List<QuickSlot> allSlots
         = new System.Collections.Generic.List<QuickSlot>();
@@ -74,6 +76,18 @@ public class QuickSlot : MonoBehaviour
                     return slot;
                 }
             }
+        }
+        return null;
+    }
+
+    public static QuickSlot GetSlotByIndex(int index)
+    {
+        for (int i = 0; i < allSlots.Count; i++)
+        {
+            var slot = allSlots[i];
+            if (slot == null) continue;
+            if (slot.quickIndex == index)
+                return slot;
         }
         return null;
     }
@@ -133,13 +147,14 @@ public class QuickSlot : MonoBehaviour
 
         linkedItem = fromItem;
         linkedItemData = fromItem.itemData;
-        linkedItemCount = fromItem.count;
+        linkedInventoryIndex = fromSlot.slotIndex;
+        linkedItemCount = linkedItem != null ? linkedItem.count : fromItem.count;
 
         ApplyIcon(fromItem.itemImage);
 
         if (linkedItemData != null && InventoryManager.Instance != null)
         {
-            InventoryManager.Instance.setQuickSlot(linkedItemData, quickIndex, linkedItemCount);
+            InventoryManager.Instance.setQuickSlot(linkedItemData, quickIndex, linkedItemCount, linkedInventoryIndex);
         }
         else
         {
@@ -149,6 +164,30 @@ public class QuickSlot : MonoBehaviour
         // 이후에 필요하면:
         // - Inventory.instance.quickSlots[quickIndex] 에도 함께 저장 (InventoryManager 연동)
         // - 단축키 입력 시 linkedItem 을 사용하는 로직 연결
+    }
+
+    public void UpdateLinkedCount(int newCount)
+    {
+        linkedItemCount = newCount;
+        if (linkedItem != null)
+            linkedItem.count = newCount;
+        UpdateCountDisplay();
+        if (linkedItemCount <= 0)
+        {
+            ClearSlotVisual();
+        }
+    }
+
+    public void ClearSlotVisual()
+    {
+        linkedItem = null;
+        linkedItemData = null;
+        linkedItemCount = 0;
+        linkedInventoryIndex = -1;
+        if (itemIcon != null)
+            itemIcon.gameObject.SetActive(false);
+        if (itemCountText != null)
+            itemCountText.gameObject.SetActive(false);
     }
 }
 

--- a/Assets/Scripts/Inven/QuickSlot.cs
+++ b/Assets/Scripts/Inven/QuickSlot.cs
@@ -1,0 +1,118 @@
+using UnityEngine;
+using UnityEngine.UI;
+using UnityEngine.EventSystems;
+
+/// <summary>
+/// 퀵슬롯(QuickSlot1~4)에 붙일 전용 스크립트.
+/// 인벤토리 슬롯에서 드래그한 아이템을 이 퀵슬롯에 등록해서
+/// 나중에 단축키(1~4번 등)로 사용할 수 있게 하기 위한 기본 구조입니다.
+/// </summary>
+public class QuickSlot : MonoBehaviour
+{
+    [Header("퀵슬롯 인덱스 (0~5)")]
+    public int quickIndex;                  // QuickSlot1 = 0, QuickSlot2 = 1, ...
+
+    [Header("UI 참조")]
+    public Image itemIcon;                  // 퀵슬롯에 표시될 아이콘
+
+    [Header("아이콘 표시 설정")]
+    [SerializeField] private Vector2 iconSize = new Vector2(64f, 64f);
+
+    [HideInInspector]
+    public InventoryItem linkedItem;        // 이 퀵슬롯과 연결된 인벤토리 아이템
+
+    private static readonly System.Collections.Generic.List<QuickSlot> allSlots
+        = new System.Collections.Generic.List<QuickSlot>();
+
+    private void Awake()
+    {
+        if (!allSlots.Contains(this))
+            allSlots.Add(this);
+
+        // 처음에는 아이콘 숨김
+        if (itemIcon != null)
+        {
+            itemIcon.gameObject.SetActive(false);
+            itemIcon.raycastTarget = false;
+        }
+    }
+
+    private void OnDestroy()
+    {
+        allSlots.Remove(this);
+    }
+
+    public static QuickSlot FindSlotUnderPointer(Vector2 screenPos, Camera uiCamera)
+    {
+        for (int i = 0; i < allSlots.Count; i++)
+        {
+            var slot = allSlots[i];
+            if (slot == null || !slot.gameObject.activeInHierarchy) continue;
+
+            RectTransform slotRect = slot.transform as RectTransform;
+            if (slotRect != null && slotRect.rect.size.sqrMagnitude > 0f &&
+                RectTransformUtility.RectangleContainsScreenPoint(slotRect, screenPos, uiCamera))
+            {
+                return slot;
+            }
+
+            if (slot.itemIcon != null)
+            {
+                RectTransform iconRect = slot.itemIcon.rectTransform;
+                if (iconRect != null &&
+                    RectTransformUtility.RectangleContainsScreenPoint(iconRect, screenPos, uiCamera))
+                {
+                    return slot;
+                }
+            }
+        }
+        return null;
+    }
+
+    private void ApplyIcon(Sprite sprite)
+    {
+        if (itemIcon == null || sprite == null) return;
+
+        itemIcon.sprite = sprite;
+        itemIcon.gameObject.SetActive(true);
+
+        RectTransform iconRect = itemIcon.rectTransform;
+        iconRect.anchorMin = new Vector2(0.5f, 0.5f);
+        iconRect.anchorMax = new Vector2(0.5f, 0.5f);
+        iconRect.pivot = new Vector2(0.5f, 0.5f);
+        iconRect.anchoredPosition = Vector2.zero;
+        iconRect.sizeDelta = iconSize;
+
+        itemIcon.preserveAspect = true;
+        itemIcon.transform.SetAsLastSibling();
+        var slotRect = transform as RectTransform;
+        if (slotRect != null && itemIcon.transform.GetSiblingIndex() <= slotRect.GetSiblingIndex())
+        {
+            itemIcon.transform.SetSiblingIndex(slotRect.GetSiblingIndex() + 1);
+        }
+    }
+
+    /// <summary>
+    /// 인벤토리의 Slot에서 끌어온 아이템을 이 퀵슬롯에 등록하는 함수.
+    /// Drag 끝났을 때 ItemDragHandler 에서 직접 호출한다.
+    /// </summary>
+    public void AssignFromSlot(Slot fromSlot)
+    {
+        if (fromSlot == null || fromSlot.item == null) return;
+
+        InventoryItem fromItem = fromSlot.item;
+
+        // 필요하면 타입 제한도 가능 (예: 힐 아이템만 올리기)
+        // if (fromItem.itemType != ItemView.Heal) return;
+
+        linkedItem = fromItem;
+
+        ApplyIcon(fromItem.itemImage);
+
+        // 이후에 필요하면:
+        // - Inventory.instance.quickSlots[quickIndex] 에도 함께 저장
+        // - 단축키 입력 시 linkedItem 을 사용하는 로직 연결
+    }
+}
+
+

--- a/Assets/Scripts/Inven/QuickSlot.cs
+++ b/Assets/Scripts/Inven/QuickSlot.cs
@@ -3,7 +3,7 @@ using UnityEngine.UI;
 using UnityEngine.EventSystems;
 
 /// <summary>
-/// 퀵슬롯(QuickSlot1~4)에 붙일 전용 스크립트.
+/// 퀵슬롯(QuickSlot1~6)에 붙일 전용 스크립트.
 /// 인벤토리 슬롯에서 드래그한 아이템을 이 퀵슬롯에 등록해서
 /// 나중에 단축키(1~4번 등)로 사용할 수 있게 하기 위한 기본 구조입니다.
 /// </summary>
@@ -14,12 +14,17 @@ public class QuickSlot : MonoBehaviour
 
     [Header("UI 참조")]
     public Image itemIcon;                  // 퀵슬롯에 표시될 아이콘
+    public Text itemCountText;             // 수량 표시 텍스트(선택)
 
     [Header("아이콘 표시 설정")]
     [SerializeField] private Vector2 iconSize = new Vector2(64f, 64f);
 
     [HideInInspector]
     public InventoryItem linkedItem;        // 이 퀵슬롯과 연결된 인벤토리 아이템
+    [HideInInspector]
+    public ItemData linkedItemData;
+    [HideInInspector]
+    public int linkedItemCount;
 
     private static readonly System.Collections.Generic.List<QuickSlot> allSlots
         = new System.Collections.Generic.List<QuickSlot>();
@@ -34,6 +39,10 @@ public class QuickSlot : MonoBehaviour
         {
             itemIcon.gameObject.SetActive(false);
             itemIcon.raycastTarget = false;
+        }
+        if (itemCountText != null)
+        {
+            itemCountText.gameObject.SetActive(false);
         }
     }
 
@@ -90,6 +99,23 @@ public class QuickSlot : MonoBehaviour
         {
             itemIcon.transform.SetSiblingIndex(slotRect.GetSiblingIndex() + 1);
         }
+
+        UpdateCountDisplay();
+    }
+
+    private void UpdateCountDisplay()
+    {
+        if (itemCountText == null) return;
+
+        if (linkedItemCount > 1)
+        {
+            itemCountText.text = linkedItemCount.ToString();
+            itemCountText.gameObject.SetActive(true);
+        }
+        else
+        {
+            itemCountText.gameObject.SetActive(false);
+        }
     }
 
     /// <summary>
@@ -106,11 +132,22 @@ public class QuickSlot : MonoBehaviour
         // if (fromItem.itemType != ItemView.Heal) return;
 
         linkedItem = fromItem;
+        linkedItemData = fromItem.itemData;
+        linkedItemCount = fromItem.count;
 
         ApplyIcon(fromItem.itemImage);
 
+        if (linkedItemData != null && InventoryManager.Instance != null)
+        {
+            InventoryManager.Instance.setQuickSlot(linkedItemData, quickIndex, linkedItemCount);
+        }
+        else
+        {
+            Debug.LogWarning($"[QuickSlot] ItemData 가 없어 퀵슬롯 {quickIndex + 1}에 등록되지 않았습니다.", this);
+        }
+
         // 이후에 필요하면:
-        // - Inventory.instance.quickSlots[quickIndex] 에도 함께 저장
+        // - Inventory.instance.quickSlots[quickIndex] 에도 함께 저장 (InventoryManager 연동)
         // - 단축키 입력 시 linkedItem 을 사용하는 로직 연결
     }
 }

--- a/Assets/Scripts/Inven/QuickSlot.cs
+++ b/Assets/Scripts/Inven/QuickSlot.cs
@@ -53,6 +53,9 @@ public class QuickSlot : MonoBehaviour
         allSlots.Remove(this);
     }
 
+    /// <summary>
+    /// 현재 포인터가 가리키는 퀵슬롯을 찾아 반환합니다.
+    /// </summary>
     public static QuickSlot FindSlotUnderPointer(Vector2 screenPos, Camera uiCamera)
     {
         for (int i = 0; i < allSlots.Count; i++)
@@ -80,6 +83,9 @@ public class QuickSlot : MonoBehaviour
         return null;
     }
 
+    /// <summary>
+    /// 등록된 퀵슬롯 리스트에서 인덱스로 검색합니다.
+    /// </summary>
     public static QuickSlot GetSlotByIndex(int index)
     {
         for (int i = 0; i < allSlots.Count; i++)
@@ -166,6 +172,9 @@ public class QuickSlot : MonoBehaviour
         // - 단축키 입력 시 linkedItem 을 사용하는 로직 연결
     }
 
+    /// <summary>
+    /// 인벤토리와 연동된 개수를 갱신해 텍스트에 반영합니다.
+    /// </summary>
     public void UpdateLinkedCount(int newCount)
     {
         linkedItemCount = newCount;
@@ -178,6 +187,9 @@ public class QuickSlot : MonoBehaviour
         }
     }
 
+    /// <summary>
+    /// 연결 정보를 모두 초기화하고 아이콘/텍스트를 숨깁니다.
+    /// </summary>
     public void ClearSlotVisual()
     {
         linkedItem = null;

--- a/Assets/Scripts/Inven/QuickSlot.cs.meta
+++ b/Assets/Scripts/Inven/QuickSlot.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6bdb2047e6c72c640a125b9eec68a868

--- a/Assets/Scripts/Inven/Slot.cs
+++ b/Assets/Scripts/Inven/Slot.cs
@@ -2,6 +2,9 @@ using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.EventSystems;
 
+/// <summary>
+/// 인벤토리 UI 한 칸을 나타내며 아이콘 표시/드랍 교환을 처리합니다.
+/// </summary>
 public class Slot : MonoBehaviour, IDropHandler
 {
     public InventoryItem item;       // 슬롯이 보유한 아이템 데이터
@@ -36,6 +39,9 @@ public class Slot : MonoBehaviour, IDropHandler
     }
 
     // 아이콘 + 텍스트 비활성화
+    /// <summary>
+    /// 아이콘과 개수 표기를 숨겨 빈 슬롯 상태로 만듭니다.
+    /// </summary>
     private void ClearVisual()
     {
         if (itemIcon != null)
@@ -46,6 +52,9 @@ public class Slot : MonoBehaviour, IDropHandler
     }
 
     // Slot UI 갱신 (아이템 아이콘/카운트)
+    /// <summary>
+    /// 슬롯에 할당된 아이템 정보를 UI 위젯에 반영합니다.
+    /// </summary>
     public void UpdateSlotUI()
     {
         if (item != null && item.itemImage != null)
@@ -71,6 +80,9 @@ public class Slot : MonoBehaviour, IDropHandler
     }
 
     // 슬롯 비우기
+    /// <summary>
+    /// 슬롯 데이터를 비우고 UI를 초기 상태로 돌립니다.
+    /// </summary>
     public void RemoveSlot()
     {
         item = null;
@@ -78,6 +90,9 @@ public class Slot : MonoBehaviour, IDropHandler
     }
 
     // 드래그된 아이템이 이 슬롯 위로 드랍되었을 때 호출됨
+    /// <summary>
+    /// 다른 슬롯에서 드래그된 아이템을 받아 이동/교환합니다.
+    /// </summary>
     public void OnDrop(PointerEventData eventData)
     {
         var drag = ItemDragHandler.currentlyDragging;

--- a/Assets/Scripts/Inven/Slot.cs
+++ b/Assets/Scripts/Inven/Slot.cs
@@ -96,18 +96,22 @@ public class Slot : MonoBehaviour, IDropHandler
         if (fromIdx < 0 || toIdx < 0) return;
         if (fromIdx >= ui.slots.Length || toIdx >= ui.slots.Length) return;
 
-        // 빈 슬롯으로 드랍하는 것 금지
-        if (inven.items[toIdx] == null)
-            return;
-
         // 필요한 경우 리스트 크기 확장
-        while (inven.items.Count <= toIdx)
+        while (inven.items.Count <= Mathf.Max(fromIdx, toIdx))
             inven.items.Add(null);
 
-        // 슬롯 아이템 교환
-        var temp = inven.items[fromIdx];
-        inven.items[fromIdx] = inven.items[toIdx];
-        inven.items[toIdx] = temp;
+        // 대상 슬롯이 비어 있으면 "이동", 아니면 "교환"
+        if (inven.items[toIdx] == null)
+        {
+            inven.items[toIdx] = inven.items[fromIdx];
+            inven.items[fromIdx] = null;
+        }
+        else
+        {
+            var temp = inven.items[fromIdx];
+            inven.items[fromIdx] = inven.items[toIdx];
+            inven.items[toIdx] = temp;
+        }
 
         // UI 갱신 이벤트 호출
         inven.onChangeItem?.Invoke();

--- a/Assets/Scripts/Manager/InventoryManager.cs
+++ b/Assets/Scripts/Manager/InventoryManager.cs
@@ -31,6 +31,8 @@ public class InventoryManager : MonoBehaviour
         HeroMoveControl = HeroTransform.GetComponent<HeroMoveControl>();
         if(HeroMoveControl == null)Debug.Log("currentViewDirection 참조 불가");
     }
+
+    // 드래그된 아이템 데이터를 지정한 퀵슬롯 인덱스에 등록합니다.
     public void setQuickSlot(ItemData item, int index, int count, int inventoryIndex)
     {
         if (index < 0 || index >= quickSlotItems.Length)
@@ -42,6 +44,8 @@ public class InventoryManager : MonoBehaviour
         quickSlotCounts[index] = count;
         quickSlotInventoryIndices[index] = inventoryIndex;
     }
+
+    // 소유 아이템 딕셔너리에 수량을 누적합니다.
     public void addItem(string itemName, int itemCnt)
     {
         if (ownedItems.ContainsKey(itemName))
@@ -55,6 +59,8 @@ public class InventoryManager : MonoBehaviour
             Debug.Log($"{itemName} 추가");
         }
     }
+
+    // 소지품에서 해당 이름의 개수를 조회합니다.
     public int getItemQuantity(string itemName)
     {
         if (ownedItems.ContainsKey(itemName))
@@ -66,6 +72,8 @@ public class InventoryManager : MonoBehaviour
             return 0;
         }
     }
+
+    // 단축키 입력으로 호출되어 퀵슬롯 아이템을 사용합니다.
     public void useQuickSlotItem(int index)
     {
         index--; // 1~6 으로 인풋이 들어옴 하나 깎고 시작
@@ -96,6 +104,7 @@ public class InventoryManager : MonoBehaviour
         else Debug.Log("사용할 수 없는 아이템");
     }
     // 슬롯 넘버로 일단은 구현
+    // UI에서 선택한 퀵슬롯 데이터를 반환하며 사용 가능 여부를 확인합니다.
     public ItemData selectItem(int slotNum)
     {
         if (slotNum < 1 || slotNum > quickSlotItems.Length)
@@ -116,6 +125,7 @@ public class InventoryManager : MonoBehaviour
         }
     }
 
+    // 퀵슬롯에 남아 있는 개수를 반환합니다.
     public int GetQuickSlotCount(int slotNum)
     {
         if (slotNum < 1 || slotNum > quickSlotCounts.Length)
@@ -126,6 +136,7 @@ public class InventoryManager : MonoBehaviour
         return quickSlotCounts[slotNum - 1];
     }
 
+    // 사용 후 퀵슬롯 수량을 줄이고 인벤토리와 UI를 동기화합니다.
     private void ConsumeQuickSlotItem(int slotIndex)
     {
         quickSlotCounts[slotIndex] = Mathf.Max(quickSlotCounts[slotIndex] - 1, 0);
@@ -151,6 +162,7 @@ public class InventoryManager : MonoBehaviour
         }
     }
 
+    // 퀵슬롯 정보를 비우고 UI 연동을 초기화합니다.
     public void ClearQuickSlotData(int slotIndex)
     {
         if (slotIndex < 0 || slotIndex >= quickSlotItems.Length) return;

--- a/Assets/Scripts/Manager/InventoryManager.cs
+++ b/Assets/Scripts/Manager/InventoryManager.cs
@@ -7,8 +7,8 @@ public class InventoryManager : MonoBehaviour
     public static InventoryManager Instance { get; private set; }
     // 전체 인벤토리 
     private Dictionary<string, int> Inventory = new Dictionary<string, int>();
-    [SerializeField]
-    public ItemData[] QuickSlot = new ItemData[4];
+    public ItemData[] QuickSlot = new ItemData[6];
+    public int[] QuickSlotCounts = new int[6];
     // itemUse를 위해 플레이어 정보, viewDirection 을 사용해야 하므로 인벤토리 매니저에서 관리함
     // viewDirection은 최신 값 반영을 위해 다이렉트로 인수로 넣음
     public Transform HeroTransform;
@@ -27,9 +27,15 @@ public class InventoryManager : MonoBehaviour
         HeroMoveControl = HeroTransform.GetComponent<HeroMoveControl>();
         if(HeroMoveControl == null)Debug.Log("currentViewDirection 참조 불가");
     }
-    public void setQuickSlot(ItemData item, int index)
+    public void setQuickSlot(ItemData item, int index, int count)
     {
+        if (index < 0 || index >= QuickSlot.Length)
+        {
+            Debug.LogWarning($"QuickSlot index {index} out of range.");
+            return;
+        }
         QuickSlot[index] = item;
+        QuickSlotCounts[index] = count;
     }
     public void addItem(string itemName, int itemCnt)
     {
@@ -57,7 +63,12 @@ public class InventoryManager : MonoBehaviour
     }
     public void useQuickSlotItem(int index)
     {
-        index--; // 1,2,3,4로 인풋이 들어옴 하나 깎고 시작
+        index--; // 1~6 으로 인풋이 들어옴 하나 깎고 시작
+        if (index < 0 || index >= QuickSlot.Length)
+        {
+            Debug.LogWarning($"QuickSlot {index + 1} 는 범위를 벗어났습니다.");
+            return;
+        }
         ItemData Item = QuickSlot[index];
         Debug.Log(Item);
         if (HeroTransform == null) Debug.Log("HeroTransform 참조 불가");
@@ -72,6 +83,11 @@ public class InventoryManager : MonoBehaviour
     // 슬롯 넘버로 일단은 구현
     public ItemData selectItem(int slotNum)
     {
+        if (slotNum < 1 || slotNum > QuickSlot.Length)
+        {
+            Debug.LogWarning($"QuickSlot {slotNum} 는 범위를 벗어났습니다.");
+            return null;
+        }
         ItemData Item = QuickSlot[slotNum-1];
         if(Item == null)
         {
@@ -83,5 +99,15 @@ public class InventoryManager : MonoBehaviour
             Debug.Log("사용할 수 없는 아이템");
             return null;
         }
+    }
+
+    public int GetQuickSlotCount(int slotNum)
+    {
+        if (slotNum < 1 || slotNum > QuickSlotCounts.Length)
+        {
+            Debug.LogWarning($"QuickSlot {slotNum} 는 범위를 벗어났습니다.");
+            return 0;
+        }
+        return QuickSlotCounts[slotNum - 1];
     }
 }

--- a/Assets/Scripts/Manager/InventoryManager.cs
+++ b/Assets/Scripts/Manager/InventoryManager.cs
@@ -6,9 +6,10 @@ public class InventoryManager : MonoBehaviour
 
     public static InventoryManager Instance { get; private set; }
     // 전체 인벤토리 
-    private Dictionary<string, int> Inventory = new Dictionary<string, int>();
-    public ItemData[] QuickSlot = new ItemData[6];
-    public int[] QuickSlotCounts = new int[6];
+    private Dictionary<string, int> ownedItems = new Dictionary<string, int>();
+    public ItemData[] quickSlotItems = new ItemData[6];
+    public int[] quickSlotCounts = new int[6];
+    public int[] quickSlotInventoryIndices = new int[6];
     // itemUse를 위해 플레이어 정보, viewDirection 을 사용해야 하므로 인벤토리 매니저에서 관리함
     // viewDirection은 최신 값 반영을 위해 다이렉트로 인수로 넣음
     public Transform HeroTransform;
@@ -22,39 +23,43 @@ public class InventoryManager : MonoBehaviour
             return;
         }
         Instance = this;
+
+        for (int i = 0; i < quickSlotInventoryIndices.Length; i++)
+            quickSlotInventoryIndices[i] = -1;
     }
     private void Start() {
         HeroMoveControl = HeroTransform.GetComponent<HeroMoveControl>();
         if(HeroMoveControl == null)Debug.Log("currentViewDirection 참조 불가");
     }
-    public void setQuickSlot(ItemData item, int index, int count)
+    public void setQuickSlot(ItemData item, int index, int count, int inventoryIndex)
     {
-        if (index < 0 || index >= QuickSlot.Length)
+        if (index < 0 || index >= quickSlotItems.Length)
         {
             Debug.LogWarning($"QuickSlot index {index} out of range.");
             return;
         }
-        QuickSlot[index] = item;
-        QuickSlotCounts[index] = count;
+        quickSlotItems[index] = item;
+        quickSlotCounts[index] = count;
+        quickSlotInventoryIndices[index] = inventoryIndex;
     }
     public void addItem(string itemName, int itemCnt)
     {
-        if (Inventory.ContainsKey(itemName))
+        if (ownedItems.ContainsKey(itemName))
         {
-            Inventory[itemName] += itemCnt;
+            ownedItems[itemName] += itemCnt;
             Debug.Log(itemName);
         }
         else
         {
-            Inventory.Add(itemName, itemCnt);
+            ownedItems.Add(itemName, itemCnt);
             Debug.Log($"{itemName} 추가");
         }
     }
     public int getItemQuantity(string itemName)
     {
-        if (Inventory.ContainsKey(itemName))
+        if (ownedItems.ContainsKey(itemName))
         {
-            return Inventory[itemName];
+            return ownedItems[itemName];
         }
         else
         {
@@ -64,12 +69,12 @@ public class InventoryManager : MonoBehaviour
     public void useQuickSlotItem(int index)
     {
         index--; // 1~6 으로 인풋이 들어옴 하나 깎고 시작
-        if (index < 0 || index >= QuickSlot.Length)
+        if (index < 0 || index >= quickSlotItems.Length)
         {
             Debug.LogWarning($"QuickSlot {index + 1} 는 범위를 벗어났습니다.");
             return;
         }
-        ItemData Item = QuickSlot[index];
+        ItemData Item = quickSlotItems[index];
         Debug.Log(Item);
         if (HeroTransform == null) Debug.Log("HeroTransform 참조 불가");
         if (Item == null)
@@ -77,18 +82,28 @@ public class InventoryManager : MonoBehaviour
             Debug.Log("빈 슬롯");
             return;
         }
-        if (Item is IUsable UsableItem) UsableItem.Use(HeroTransform, HeroMoveControl.CurrentViewDirection);
+        if (quickSlotCounts[index] <= 0)
+        {
+            Debug.Log("퀵슬롯 아이템이 소진되었습니다.");
+            ClearQuickSlotData(index);
+            return;
+        }
+        if (Item is IUsable UsableItem)
+        {
+            UsableItem.Use(HeroTransform, HeroMoveControl.CurrentViewDirection);
+            ConsumeQuickSlotItem(index);
+        }
         else Debug.Log("사용할 수 없는 아이템");
     }
     // 슬롯 넘버로 일단은 구현
     public ItemData selectItem(int slotNum)
     {
-        if (slotNum < 1 || slotNum > QuickSlot.Length)
+        if (slotNum < 1 || slotNum > quickSlotItems.Length)
         {
             Debug.LogWarning($"QuickSlot {slotNum} 는 범위를 벗어났습니다.");
             return null;
         }
-        ItemData Item = QuickSlot[slotNum-1];
+        ItemData Item = quickSlotItems[slotNum-1];
         if(Item == null)
         {
             Debug.Log("빈 슬롯");
@@ -103,11 +118,50 @@ public class InventoryManager : MonoBehaviour
 
     public int GetQuickSlotCount(int slotNum)
     {
-        if (slotNum < 1 || slotNum > QuickSlotCounts.Length)
+        if (slotNum < 1 || slotNum > quickSlotCounts.Length)
         {
             Debug.LogWarning($"QuickSlot {slotNum} 는 범위를 벗어났습니다.");
             return 0;
         }
-        return QuickSlotCounts[slotNum - 1];
+        return quickSlotCounts[slotNum - 1];
+    }
+
+    private void ConsumeQuickSlotItem(int slotIndex)
+    {
+        quickSlotCounts[slotIndex] = Mathf.Max(quickSlotCounts[slotIndex] - 1, 0);
+
+        int inventoryIndex = quickSlotInventoryIndices[slotIndex];
+        int latestCount = quickSlotCounts[slotIndex];
+
+        if (Inventory.instance != null && inventoryIndex >= 0)
+        {
+            latestCount = Inventory.instance.ConsumeItemAt(inventoryIndex, 1);
+            quickSlotCounts[slotIndex] = latestCount;
+        }
+
+        var slot = QuickSlot.GetSlotByIndex(slotIndex);
+        if (slot != null)
+        {
+            slot.UpdateLinkedCount(latestCount);
+        }
+
+        if (latestCount <= 0)
+        {
+            ClearQuickSlotData(slotIndex);
+        }
+    }
+
+    public void ClearQuickSlotData(int slotIndex)
+    {
+        if (slotIndex < 0 || slotIndex >= quickSlotItems.Length) return;
+        quickSlotItems[slotIndex] = null;
+        quickSlotCounts[slotIndex] = 0;
+        quickSlotInventoryIndices[slotIndex] = -1;
+
+        var slot = QuickSlot.GetSlotByIndex(slotIndex);
+        if (slot != null)
+        {
+            slot.ClearSlotVisual();
+        }
     }
 }


### PR DESCRIPTION
## 🚀 Background
- 퀵 슬롯 구현 (1~6)
- 장비 슬롯 구현 (위에서부터 랜턴, 신발(임시로 포션), 무기)
- 기존의 인벤토리와 연결
```
Inventory Canvas
│
├── InventoryUI
│
├── EquipPanel
│   ├── Image
│   ├── Image
│   ├── Image
│   ├── LanternSlot
│   ├── ShoesSlot
│   └── WeaponSlot
│
├── QuickSlotPanel
│   ├── QuickSlot1
│   ├── QuickSlot2
│   ├── QuickSlot3
│   ├── QuickSlot4
│   ├── QuickSlot5
│   └── QuickSlot6
│
└── ItemDatabase

```

기존 Inventory Canvas에서 새로운 Panel 두가지 추가

## 🥥 Changes
- 장비슬롯 전용 스크립트 추가 및 구현
EquipPanel에 있는 기존의 슬롯 프리팹에서 slot.cs, ItemDragHandler 비활성화
-> 활성화 시키면 아이템 DB가 꼬이고 슬롯 칸이 움직이기 때문에 비활성화
-> 새로 만든 EquipSlot스크립트를 대신 추가
<img width="298" height="203" alt="image" src="https://github.com/user-attachments/assets/2df393b1-58c7-4874-ad1f-416786b132df" />

- 반드시 아이템 타입 지정및 슬롭 프리팹 하위 객체인 ItemImage를 추가 해줘야된다
- 아이템 타입이 맞지 않으면 장착이 안된다
- 인벤토리에서 아이템 땡겨오면 자동으로 적용 
- 인벤토리에서 가져오면 인벤토리에 있던 슬롯은 비게 되어 새로운 아이템을 담을수 있다.
- 현재 신발 타입은 따로 없어서 Heal로 대신 구현 해놓은 상태


- 퀵슬롯 전용 스크립트 추가 및 구현
EquipPanel과 마찬가지로 기존의 슬롯 프리팹에서 slot.cs,ItemDragHandler 비활성화
-> 새로 만든 QuickSlot스크립트 추가
-> 1~6번 키로 사용 가능
<img width="304" height="217" alt="image" src="https://github.com/user-attachments/assets/86cda364-6700-4151-85ea-e17aee32b016" />

각각의 프리팹에 인덱스 및 슬롯 프리팹에 하위객체인 이미지, itemCount 추가 필요
<img width="300" height="158" alt="image" src="https://github.com/user-attachments/assets/83785f9a-c1dc-4452-83a4-414510411107" />

아이템 마다 ItemDataAsset을 추가해줘야 아이템 사용이 가능
기존의 DB와 연결 완료
예) 아이템을 사용하면 db에서 카운트가 같이 줄어든다
- 장비슬롯과 다르게 아이템을 드래그한다고 인벤토리에서 사라지는게 아니라 사용만 용이하게 수정

- 전반 적인 Inven 스크립트 전부 수정 및 UI 수정

## 🪪 ID
- FR-023-1-1
- FR-023-1-2
- FR-044-1-1
- FR-044-1-2

## ⚓ Related Issue
- closes #106 
