### PR TITLE
[FR-ITEM/fix/#111] 인벤토리 및 슬롯 아이템 연결. 즉시 사용 기능 추가

### DIFF
--- a/Assets/Prefabs/MedicineItem.prefab
+++ b/Assets/Prefabs/MedicineItem.prefab
@@ -209,7 +209,7 @@ MonoBehaviour:
   itemType: 0
   itemName: Heal2
   itemImage: {fileID: 4475158985010180414, guid: a4d9ddf8d7e6b0146a1fdbc0159db0f4, type: 3}
-  itemDataAsset: {fileID: 11400000, guid: 83ac069170f18d34d9953b37b617dbfe, type: 2}
+  itemDataAsset: {fileID: 11400000, guid: 9c1138427c389d541bd0800745e86e5d, type: 2}
 --- !u!114 &-295572257772085249
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/WeaponItem.prefab
+++ b/Assets/Prefabs/WeaponItem.prefab
@@ -222,3 +222,4 @@ MonoBehaviour:
   itemType: 1
   itemName: Pistol
   itemImage: {fileID: 4319395737909131107, guid: 6890018106e5f7447b4235e6666564e1, type: 3}
+  itemDataAsset: {fileID: 11400000, guid: 01fc2da11691b7d45b6e4d9a45d091fb, type: 2}

--- a/Assets/Scripts/HeroItemUse.cs
+++ b/Assets/Scripts/HeroItemUse.cs
@@ -10,6 +10,7 @@ public class HeroItemUse : MonoBehaviour
 
     private HeroMoveControl HeroMoveControl;
     private ItemData selectedItem;
+    private int selectedItemIndex;
     private Vector2 mouseDirection;
     void Start()
     {
@@ -39,37 +40,38 @@ public class HeroItemUse : MonoBehaviour
             // 정규화
             mouseDirection.Normalize();
 
-            // 사용 가능한 아이템일 경우(IUsable 규칙을 상속받은 데이터의 경우) Use 메서드가 존재함
-            if(selectedItem is IUsable usableData)usableData.Use(transform,mouseDirection);
-            else Debug.Log("사용할 수 없는 아이템");
+            UseQuickSlot(selectedItemIndex,transform,mouseDirection);
+            // // 사용 가능한 아이템일 경우(IUsable 규칙을 상속받은 데이터의 경우) Use 메서드가 존재함
+            // if(selectedItem is IUsable usableData)usableData.Use(transform,mouseDirection);
+            // else Debug.Log("사용할 수 없는 아이템");
         }
     }
     public void OnQuickSlot1(InputAction.CallbackContext context)
     {
         if (context.performed)
         {
-            UseQuickSlot(1);
+            selectedItemIndex = 1;
         }
     }
     public void OnQuickSlot2(InputAction.CallbackContext context)
     {
         if (context.performed)
         {
-            UseQuickSlot(2);
+            selectedItemIndex = 2;
         }
     }
     public void OnQuickSlot3(InputAction.CallbackContext context)
     {
         if (context.performed)
         {
-            UseQuickSlot(3);
+            selectedItemIndex = 3;
         }
     }
     public void OnQuickSlot4(InputAction.CallbackContext context)
     {
         if (context.performed)
         {
-            UseQuickSlot(4);
+            selectedItemIndex = 4;
         }
     }
 
@@ -77,7 +79,7 @@ public class HeroItemUse : MonoBehaviour
     {
         if (context.performed)
         {
-            UseQuickSlot(5);
+            selectedItemIndex = 5;
         }
     }
 
@@ -85,11 +87,11 @@ public class HeroItemUse : MonoBehaviour
     {
         if (context.performed)
         {
-            UseQuickSlot(6);
+            selectedItemIndex = 6;
         }
     }
 
-    private void UseQuickSlot(int slotNumber)
+    private void UseQuickSlot(int slotNumber,Transform heroT, Vector2 useVec)
     {
         if (InventoryManager.Instance == null)
         {
@@ -97,7 +99,7 @@ public class HeroItemUse : MonoBehaviour
             return;
         }
 
-        InventoryManager.Instance.useQuickSlotItem(slotNumber);
+        InventoryManager.Instance.useQuickSlotItem(slotNumber,heroT,useVec);
     }
 
     // 실시간 마우스 위치를 얻어와서 해당 위치에 ui가 있는지 확인하기 위함.

--- a/Assets/Scripts/Inven/EquipSlot.cs
+++ b/Assets/Scripts/Inven/EquipSlot.cs
@@ -153,7 +153,7 @@ public class EquipSlot : MonoBehaviour
         Debug.Log($"[EquipSlot] EquipFromSlot 호출됨. 아이템: {fromItem.itemName}, 타입: {fromItem.itemType}", this);
 
         // 타입이 맞는 아이템만 장착
-        if (fromItem.itemType != acceptedType)
+        if (acceptedType != fromItem.itemType)
         {
             Debug.LogWarning($"[EquipSlot] EquipFromSlot: 타입 불일치. 이 슬롯: {acceptedType}, 아이템 타입: {fromItem.itemType}", this);
             return;
@@ -179,6 +179,9 @@ public class EquipSlot : MonoBehaviour
             int idx = fromSlot.slotIndex;
             if (idx >= 0 && idx < inven.items.Count)
             {
+                // 장착하자 마자 사용 되도록
+                if(inven.items[idx].itemData is IUsable usable)usable.Use(HeroStat.Instance.transform,Vector2.zero);
+                
                 inven.items[idx] = null;
                 inven.onChangeItem?.Invoke();   // 인벤 UI 다시 그리기
                 Debug.Log($"[EquipSlot] 인벤토리 {idx}번 슬롯 아이템 제거 완료.", this);

--- a/Assets/Scripts/Inven/ItemDragHandler.cs
+++ b/Assets/Scripts/Inven/ItemDragHandler.cs
@@ -117,10 +117,15 @@ public class ItemDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler, I
 
         if (!handled)
         {
-            QuickSlot quickSlot = QuickSlot.FindSlotUnderPointer(pointerPos, uiCamera);
-            if (quickSlot != null)
+            // 슬롯에 못넣는 아이템
+            if(slot.item.itemType != ItemView.Weapon
+            && slot.item.itemType != ItemView.Lantern)
             {
-                quickSlot.AssignFromSlot(slot);
+                QuickSlot quickSlot = QuickSlot.FindSlotUnderPointer(pointerPos, uiCamera);
+                if (quickSlot != null)
+                {
+                    quickSlot.AssignFromSlot(slot);
+                }
             }
         }
 

--- a/Assets/Scripts/Item_cs/HealItem/Band_200.asset
+++ b/Assets/Scripts/Item_cs/HealItem/Band_200.asset
@@ -18,6 +18,8 @@ MonoBehaviour:
   MaxStackCount: 0
   isAvailable: 0
   coolTime: 0
-  whichStat: []
-  healAmount: []
+  whichStat:
+  - hp
+  healAmount:
+  - 50
   buffDuration: 0

--- a/Assets/Scripts/Item_cs/SpecialItem/Lantern_300.asset
+++ b/Assets/Scripts/Item_cs/SpecialItem/Lantern_300.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0fbf43c6e4495ed4fb7e6a5648dda85c, type: 3}
   m_Name: Lantern_300
   m_EditorClassIdentifier: Assembly-CSharp::LanternData
-  ItemName: 0
+  ItemName: 300
   Description: 
   Icon: {fileID: 0}
   MaxStackCount: 1

--- a/Assets/Scripts/Manager/InventoryManager.cs
+++ b/Assets/Scripts/Manager/InventoryManager.cs
@@ -74,7 +74,7 @@ public class InventoryManager : MonoBehaviour
     }
 
     // 단축키 입력으로 호출되어 퀵슬롯 아이템을 사용합니다.
-    public void useQuickSlotItem(int index)
+    public void useQuickSlotItem(int index,Transform heroT,Vector2 useVec)
     {
         index--; // 1~6 으로 인풋이 들어옴 하나 깎고 시작
         if (index < 0 || index >= quickSlotItems.Length)
@@ -98,8 +98,8 @@ public class InventoryManager : MonoBehaviour
         }
         if (Item is IUsable UsableItem)
         {
-            UsableItem.Use(HeroTransform, HeroMoveControl.CurrentViewDirection);
-            ConsumeQuickSlotItem(index);
+            UsableItem.Use(heroT, useVec);
+            if(Item.getItemName / 100 != 1)ConsumeQuickSlotItem(index);
         }
         else Debug.Log("사용할 수 없는 아이템");
     }


### PR DESCRIPTION
## 🚀 Background
- 현재까지 파밍 되는 아이템 전부 퀵슬롯이나 장비슬롯에서 사용 가능
- 장비 슬롯 장착 시 자동으로 실행되게 구현
- 퀵슬롯에서 아이템 사용 시 무기아이템에 한정해 갯수가 줄어들지 않게 설정
## 🥥 Changes

## 🧪 Testing
- 신발 아이템이 구현되어 있지 않음.
- 신발 아이템 구현 시 다른 의류 아이템도 추가하는 것이 좋아 보임.
- equipSlot 에 weapon을 두는 것이 맞지 않는 것 같음. 사용 방식이 다른 아이템들과 다르지 않고 해당 기능 구현 시 퀵슬롯과 독립적으로 실행 기능을 두어야 함
## 📸 Screenshots

## ✍🏻 References

## 🪪 ID

## ⚓ Related Issue
- closes #111 
