### PR TITLE
[FR-033/feat/#162] 공격방향으로 스프라이트 전환 기능 추가

### DIFF
--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -1492,8 +1492,6 @@ MonoBehaviour:
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
   slotHolder: {fileID: 524732905}
 --- !u!1 &324306656 stripped
 GameObject:
@@ -2505,128 +2503,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
---- !u!1001 &465214421
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 524732905}
-    m_Modifications:
-    - target: {fileID: 1523823183359281106, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_Name
-      value: Slot (19)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4880298685924066059, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 4796889811297207966, guid: a55d747ea343520479b7362009ebdf8b, type: 3}
-    - target: {fileID: 4880298685924066059, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_Color.b
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4880298685924066059, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_Color.g
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4880298685924066059, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_Color.r
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4880298685924066059, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_PixelsPerUnitMultiplier
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
---- !u!224 &465214422 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-  m_PrefabInstance: {fileID: 465214421}
-  m_PrefabAsset: {fileID: 0}
 --- !u!224 &477014831 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
@@ -3348,8 +3224,6 @@ RectTransform:
   - {fileID: 2139607309}
   - {fileID: 2116165126}
   - {fileID: 2071541180}
-  - {fileID: 1687266205}
-  - {fileID: 465214422}
   m_Father: {fileID: 1263910626}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
@@ -78819,8 +78693,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0.648407, y: -41.194}
-  m_SizeDelta: {x: -33.7031, y: -197.612}
+  m_AnchoredPosition: {x: 0.648407, y: -17.403}
+  m_SizeDelta: {x: -33.7031, y: -36.806}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &737229259
 MonoBehaviour:
@@ -94026,8 +93900,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 220, y: 270}
-  m_SizeDelta: {x: 50, y: 50}
+  m_AnchoredPosition: {x: 60, y: -250}
+  m_SizeDelta: {x: 75, y: 75}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1024259313
 MonoBehaviour:
@@ -94423,6 +94297,96 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1108392629}
   m_CullTransparentMesh: 1
+--- !u!1 &1121870514
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1121870515}
+  - component: {fileID: 1121870516}
+  m_Layer: 0
+  m_Name: Hero_N
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1121870515
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1121870514}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.003, y: 0.019, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1380755839}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1121870516
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1121870514}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 20
+  m_Sprite: {fileID: 4749400669287065316, guid: 002840da27931604a945e08698fbb419, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.25, y: 0.734375}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1 &1133050478
 GameObject:
   m_ObjectHideFlags: 0
@@ -94908,7 +94872,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2f6895eb39c4d1e43b67a6f28dc48980, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::ClockHUD
-  Timer: 0
   ClockHand: {fileID: 1182605791}
 --- !u!1 &1183453551
 GameObject:
@@ -96278,6 +96241,8 @@ GameObject:
   - component: {fileID: 1380755850}
   - component: {fileID: 1380755851}
   - component: {fileID: 1380755852}
+  - component: {fileID: 1380755853}
+  - component: {fileID: 1380755854}
   m_Layer: 0
   m_Name: Hero
   m_TagString: Player
@@ -96304,6 +96269,10 @@ Transform:
   - {fileID: 1833716095}
   - {fileID: 73104499}
   - {fileID: 60767743}
+  - {fileID: 1952668113}
+  - {fileID: 1448203052}
+  - {fileID: 1121870515}
+  - {fileID: 1427146341}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!50 &1380755841
@@ -96587,7 +96556,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0152c5649693ba04d91705c51b17084f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::HeroMoveControl
-  stepTime: 0.4
   inputActions: {fileID: -944628639613478452, guid: 2bcd2660ca9b64942af0de543d8d7100, type: 3}
   initHeroPosition: {x: 0.5, y: -4.5}
   attackAnimDuration: 0.5
@@ -96808,6 +96776,40 @@ MonoBehaviour:
   pistol_N: {fileID: 1833716094}
   pistol_W: {fileID: 60767742}
   pistol_E: {fileID: 73104498}
+--- !u!114 &1380755853
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1380755837}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 331f193343a0c674291146b20f527e34, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::HeroAttackFlash
+  hero_S: {fileID: 1952668112}
+  hero_N: {fileID: 1121870514}
+  hero_W: {fileID: 1427146340}
+  hero_E: {fileID: 1448203051}
+  animator: {fileID: 1380755850}
+  baseRenderer: {fileID: 0}
+--- !u!114 &1380755854
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1380755837}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ae28e282c48b4f9468c354ee75335d8b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::HeroWeaponVisual
+  pistol_S: {fileID: 976036693}
+  pistol_N: {fileID: 1833716094}
+  pistol_W: {fileID: 60767742}
+  pistol_E: {fileID: 73104498}
 --- !u!1 &1414283291
 GameObject:
   m_ObjectHideFlags: 0
@@ -97005,6 +97007,96 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+--- !u!1 &1427146340
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1427146341}
+  - component: {fileID: 1427146342}
+  m_Layer: 0
+  m_Name: Hero_W
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1427146341
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1427146340}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.034, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1380755839}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1427146342
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1427146340}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 20
+  m_Sprite: {fileID: 4899215582445571646, guid: 3abaabb083712c6468d5b11787f02d4b, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.34375, y: 0.71875}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1001 &1440649888
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -97118,6 +97210,96 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
+--- !u!1 &1448203051
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1448203052}
+  - component: {fileID: 1448203053}
+  m_Layer: 0
+  m_Name: Hero_E
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1448203052
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1448203051}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.028, y: 0.001, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1380755839}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1448203053
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1448203051}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 20
+  m_Sprite: {fileID: -6571406813763657576, guid: 40458f52ac9e22842a44dec5cd99d6a5, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.34375, y: 0.71875}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1 &1454200434
 GameObject:
   m_ObjectHideFlags: 0
@@ -98274,128 +98456,6 @@ RectTransform:
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
   m_PrefabInstance: {fileID: 2095771566}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1687266204
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 524732905}
-    m_Modifications:
-    - target: {fileID: 1523823183359281106, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_Name
-      value: Slot (18)
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4880298685924066059, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 4796889811297207966, guid: a55d747ea343520479b7362009ebdf8b, type: 3}
-    - target: {fileID: 4880298685924066059, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_Color.b
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4880298685924066059, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_Color.g
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4880298685924066059, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_Color.r
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4880298685924066059, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-      propertyPath: m_PixelsPerUnitMultiplier
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
---- !u!224 &1687266205 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
-  m_PrefabInstance: {fileID: 1687266204}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1693186285
 PrefabInstance:
@@ -99937,6 +99997,96 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 1512510980}
   m_SourcePrefab: {fileID: 100100000, guid: 136a1c324c1eb5946a440ea73dfe6188, type: 3}
+--- !u!1 &1952668112
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1952668113}
+  - component: {fileID: 1952668114}
+  m_Layer: 0
+  m_Name: Hero_S
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1952668113
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1952668112}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.002, y: -0.025, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1380755839}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1952668114
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1952668112}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 20
+  m_Sprite: {fileID: 3420486963420910619, guid: 340b48294a556bb418c4c0ba53492f05, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.25, y: 0.734375}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1001 &1976465383
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -100538,7 +100688,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 250, y: -470}
+  m_AnchoredPosition: {x: 177, y: -251}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2036325072
@@ -102248,3 +102398,4 @@ SceneRoots:
   - {fileID: 1635730878}
   - {fileID: 563287752}
   - {fileID: 1154482405}
+  - {fileID: 13734523}

--- a/Assets/Scripts/HeroAttackFlash.cs
+++ b/Assets/Scripts/HeroAttackFlash.cs
@@ -1,0 +1,122 @@
+using System.Collections;
+using UnityEngine;
+
+/// <summary>
+/// Hero 하위에 있는 Hero_S / Hero_N / Hero_W / Hero_E 이미지를
+/// "공격 방향"에 맞게 잠깐 보여주는 스크립트.
+/// 
+/// - Animator를 잠깐 껐다가 다시 켜면서,
+/// - 지정한 시간동안만 해당 방향 이미지를 SetActive(true) 했다가 false 로 돌려놓는다.
+/// </summary>
+public class HeroAttackFlash : MonoBehaviour
+{
+    [Header("공격 방향별 Hero 이미지 (Hero 하위 자식)")]
+    [SerializeField] private GameObject hero_S;
+    [SerializeField] private GameObject hero_N;
+    [SerializeField] private GameObject hero_W;
+    [SerializeField] private GameObject hero_E;
+
+    [Header("Hero 애니메이터")]
+    [SerializeField] private Animator animator;
+
+    [Header("기본 Hero 이미지 (애니메이터가 그려주는 본체 스프라이트)")]
+    [SerializeField] private SpriteRenderer baseRenderer;
+    private bool baseRendererWasEnabled;
+
+    private void Awake()
+    {
+        // 시작 시 전부 끈 상태로 시작
+        SetAll(false);
+
+        // 인스펙터에서 안 넣어줬다면 자동으로 찾아보기
+        if (animator == null)
+        {
+            animator = GetComponent<Animator>();
+        }
+
+        if (baseRenderer == null)
+        {
+            baseRenderer = GetComponent<SpriteRenderer>();
+        }
+    }
+
+    /// <summary>
+    /// 공격 방향(dir)에 맞는 Hero_* 이미지를 잠깐 보여준다.
+    /// dir은 마우스 방향 등 "공격하려는 방향" 벡터.
+    /// </summary>
+    public void ShowAttack(Vector2 dir, float duration = 0.1f)
+    {
+        // 0벡터면 아무 것도 하지 않음
+        if (dir.sqrMagnitude < 0.0001f)
+            return;
+
+        StartCoroutine(ShowAttackRoutine(dir, duration));
+    }
+
+    private IEnumerator ShowAttackRoutine(Vector2 dir, float duration)
+    {
+        // 기본 Hero 스프라이트 잠깐 끄기 (현재 애니메이션 프레임 숨기기)
+        if (baseRenderer != null)
+        {
+            baseRendererWasEnabled = baseRenderer.enabled;
+            baseRenderer.enabled = false;
+        }
+
+        // 애니메이터 잠깐 끄기 (애니메이션 진행 정지)
+        if (animator != null)
+            animator.enabled = false;
+
+        // 전부 끄고 시작
+        SetAll(false);
+
+        // 방향 스냅: 더 큰 축 기준으로 4방향 중 하나 선택
+        if (Mathf.Abs(dir.x) > Mathf.Abs(dir.y))
+        {
+            if (dir.x < 0)
+            {
+                if (hero_W != null) hero_W.SetActive(true);
+            }
+            else
+            {
+                if (hero_E != null) hero_E.SetActive(true);
+            }
+        }
+        else
+        {
+            if (dir.y < 0)
+            {
+                if (hero_S != null) hero_S.SetActive(true);
+            }
+            else
+            {
+                if (hero_N != null) hero_N.SetActive(true);
+            }
+        }
+
+        // 잠깐 보여주기
+        yield return new WaitForSeconds(duration);
+
+        // 다시 끄기 (공격 방향용 Hero_* 이미지 비활성화)
+        SetAll(false);
+
+        // 기본 Hero 스프라이트 다시 보이기
+        if (baseRenderer != null)
+        {
+            baseRenderer.enabled = baseRendererWasEnabled;
+        }
+
+        // 애니메이터 다시 켜기 (원래 애니메이션 상태 재개)
+        if (animator != null)
+            animator.enabled = true;
+    }
+
+    private void SetAll(bool visible)
+    {
+        if (hero_S != null) hero_S.SetActive(visible);
+        if (hero_N != null) hero_N.SetActive(visible);
+        if (hero_W != null) hero_W.SetActive(visible);
+        if (hero_E != null) hero_E.SetActive(visible);
+    }
+}
+
+

--- a/Assets/Scripts/HeroAttackFlash.cs.meta
+++ b/Assets/Scripts/HeroAttackFlash.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 331f193343a0c674291146b20f527e34

--- a/Assets/Scripts/HeroItemUse.cs
+++ b/Assets/Scripts/HeroItemUse.cs
@@ -9,6 +9,8 @@ public class HeroItemUse : MonoBehaviour
 {
 
     private HeroMoveControl HeroMoveControl;
+    private HeroAttackFlash heroAttackFlash;
+    private HeroWeaponVisual heroWeaponVisual;
     private ItemData selectedItem;
     private int selectedItemIndex;
     private Vector2 mouseDirection;
@@ -21,6 +23,17 @@ public class HeroItemUse : MonoBehaviour
             Debug.Log("heroMoveControl 참조 불가");
         }
 
+        heroAttackFlash = GetComponent<HeroAttackFlash>();
+        if (heroAttackFlash == null)
+        {
+            Debug.Log("HeroAttackFlash 참조 불가 (Hero 하위 Hero_S/N/W/E 이미지를 사용한 공격 플래시를 쓰지 않음)");
+        }
+
+        heroWeaponVisual = GetComponent<HeroWeaponVisual>();
+        if (heroWeaponVisual == null)
+        {
+            Debug.Log("HeroWeaponVisual 참조 불가 (총 스프라이트 회전/표시 관리 안 함)");
+        }
     }
     public void OnItemUse(InputAction.CallbackContext context)
     {
@@ -39,6 +52,24 @@ public class HeroItemUse : MonoBehaviour
             mouseDirection = mouseWorldPosition - (Vector2)transform.position;
             // 정규화
             mouseDirection.Normalize();
+
+            // 현재 선택된 퀵슬롯 아이템이 무기일 경우에만 HeroAttackFlash / 총 임시 방향 전환 실행
+            var currentData = GetSelectedQuickSlotItem();
+            bool isWeapon = currentData != null && IsWeaponData(currentData);
+            if (isWeapon)
+            {
+                if (heroAttackFlash != null)
+                {
+                    heroAttackFlash.ShowAttack(mouseDirection);
+                }
+
+                if (heroWeaponVisual != null)
+                {
+                    // 공격 방향(마우스 방향)을 기준으로 잠깐 다른 방향/각도로 총을 보여줬다가
+                    // duration 이후에 원래 상태로 자동 복귀
+                    heroWeaponVisual.ShowAttackOverride(mouseDirection, 0.1f);
+                }
+            }
 
             UseQuickSlot(selectedItemIndex,transform,mouseDirection);
             // // 사용 가능한 아이템일 경우(IUsable 규칙을 상속받은 데이터의 경우) Use 메서드가 존재함

--- a/Assets/Scripts/HeroMoveControl.cs
+++ b/Assets/Scripts/HeroMoveControl.cs
@@ -11,7 +11,7 @@ public class HeroMoveControl : MonoBehaviour
     private Vector2 currentViewDirection = new Vector2(0f, -1f);
     public Vector2 CurrentViewDirection => currentViewDirection;
 
-    [SerializeField] private float stepTime = 0.4f; // HeroStat.speed를 이용해 실제 속도를 계산할 때 쓰는 기준 시간
+    // private float stepTime = 0.4f; // HeroStat.speed를 이용해 실제 속도를 계산할 때 쓰는 기준 시간 (현재 사용하지 않음)
 
     private float moveSpeed;                         // 최종 이동 속도
     private const float minMoveSpeed = 0.5f;         // 이동 속도의 최소값

--- a/Assets/Scripts/HeroWeaponVisual.cs
+++ b/Assets/Scripts/HeroWeaponVisual.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using UnityEngine;
 
 /// <summary>
@@ -30,6 +31,11 @@ public class HeroWeaponVisual : MonoBehaviour
     }
 
     private Direction facingDir = Direction.South; // 기본은 아래 방향
+
+    // 공격 시 잠깐 다른 방향으로 보여줬다가 되돌리기 위한 저장용 변수들
+    private Direction previousFacingDir;
+    private Quaternion prevRotS, prevRotN, prevRotW, prevRotE;
+    private Coroutine attackOverrideRoutine;
 
     private void Awake()
     {
@@ -110,6 +116,84 @@ public class HeroWeaponVisual : MonoBehaviour
                 if (pistol_E != null) pistol_E.SetActive(true);
                 break;
         }
+    }
+
+    /// <summary>
+    /// 공격/조준 방향 벡터를 받아 총 스프라이트들을 해당 방향으로 회전시킨다.
+    /// (현재 활성화된 Pistol_* 하나만 보이지만, 안전하게 네 개 모두 같은 각도로 맞춰둔다)
+    /// </summary>
+    public void RotateGun(Vector2 dir)
+    {
+        if (dir.sqrMagnitude < 0.0001f)
+            return;
+
+        // Atan2로 2D 방향을 각도(도 단위)로 변환. (오른쪽이 0도 기준)
+        float angle = Mathf.Atan2(dir.y, dir.x) * Mathf.Rad2Deg;
+
+        // 왼쪽(West)으로 쏠 때 스프라이트가 거꾸로 보이면 보정용으로 180도 추가 회전
+        if (facingDir == Direction.West)
+        {
+            angle += 180f;
+        }
+
+        Quaternion rot = Quaternion.AngleAxis(angle, Vector3.forward);
+
+        if (pistol_S != null) pistol_S.transform.rotation = rot;
+        if (pistol_N != null) pistol_N.transform.rotation = rot;
+        if (pistol_W != null) pistol_W.transform.rotation = rot;
+        if (pistol_E != null) pistol_E.transform.rotation = rot;
+    }
+
+    /// <summary>
+    /// 공격할 때 잠깐 다른 방향으로 총을 보여줬다가,
+    /// 일정 시간 후에 원래 방향/회전 상태로 되돌린다.
+    /// (HeroAttackFlash와 짝을 이뤄서 사용)
+    /// </summary>
+    public void ShowAttackOverride(Vector2 dir, float duration = 0.1f)
+    {
+        if (dir.sqrMagnitude < 0.0001f)
+            return;
+
+        // 이전에 돌리던 코루틴이 있으면 먼저 원상복구
+        if (attackOverrideRoutine != null)
+        {
+            StopCoroutine(attackOverrideRoutine);
+            RestorePreviousState();
+            attackOverrideRoutine = null;
+        }
+
+        // 현재 상태 저장
+        previousFacingDir = facingDir;
+        if (pistol_S != null) prevRotS = pistol_S.transform.rotation;
+        if (pistol_N != null) prevRotN = pistol_N.transform.rotation;
+        if (pistol_W != null) prevRotW = pistol_W.transform.rotation;
+        if (pistol_E != null) prevRotE = pistol_E.transform.rotation;
+
+        // 공격 방향을 기준으로 임시 방향 설정 + 총 활성/회전
+        UpdateDirection(dir);   // 이 안에서 facingDir을 dir 기준으로 스냅 + 활성 Pistol_* 변경
+        RotateGun(dir);         // 실제 조준 각도로 회전
+
+        // duration 후에 원상 복구
+        attackOverrideRoutine = StartCoroutine(RestoreAfterDelay(duration));
+    }
+
+    private IEnumerator RestoreAfterDelay(float duration)
+    {
+        yield return new WaitForSeconds(duration);
+        RestorePreviousState();
+        attackOverrideRoutine = null;
+    }
+
+    private void RestorePreviousState()
+    {
+        // 구르는 중이면 어차피 안 보이므로, 상태만 되돌려놓고 표시 갱신은 롤 끝날 때 처리돼도 됨
+        facingDir = previousFacingDir;
+        UpdatePistolVisible();
+
+        if (pistol_S != null) pistol_S.transform.rotation = prevRotS;
+        if (pistol_N != null) pistol_N.transform.rotation = prevRotN;
+        if (pistol_W != null) pistol_W.transform.rotation = prevRotW;
+        if (pistol_E != null) pistol_E.transform.rotation = prevRotE;
     }
 }
 

--- a/Assets/Scripts/Manager/InventoryManager.cs
+++ b/Assets/Scripts/Manager/InventoryManager.cs
@@ -113,7 +113,9 @@ public class InventoryManager : MonoBehaviour
         }
         ItemData Item = quickSlotItems[index];
         Debug.Log(Item);
-        if (HeroTransform == null) Debug.Log("HeroTransform 참조 불가");
+
+        if (HeroTransform == null)
+            Debug.LogWarning("[InventoryManager] HeroTransform 참조 불가 (HeroTransform이 인스펙터에서 연결되어 있는지 확인하세요).");
         if (Item == null)
         {
             Debug.Log("빈 슬롯");
@@ -127,16 +129,46 @@ public class InventoryManager : MonoBehaviour
         }
         if (Item is IUsable UsableItem)
         {
-            // 쿨타임 체크
-            if (!(CoolTimeManager.Instance.GetCurrentCooltime(Item.getItemName) > 0))
+            // 쿨타임 매니저가 없으면 경고만 찍고, 쿨타임 없이 아이템은 사용 가능하게 처리
+            bool hasCoolTimeManager = CoolTimeManager.Instance != null;
+            bool isOnCooldown = false;
+
+            if (hasCoolTimeManager)
+            {
+                isOnCooldown = CoolTimeManager.Instance.GetCurrentCooltime(Item.getItemName) > 0;
+            }
+            else
+            {
+                Debug.LogWarning("[InventoryManager] CoolTimeManager.Instance 가 null 입니다. 쿨타임 없이 아이템을 사용합니다.");
+            }
+
+            // 쿨타임이 없거나(매니저 없음 포함), 현재 쿨타임이 0 이하일 때만 사용
+            if (!isOnCooldown)
             {
                 // 임시로 그냥 ConsumeQuickSlotItem 호출
-                if (Item.getItemName / 100 != 1)ConsumeQuickSlotItem(index);
+                if (Item.getItemName / 100 != 1)
+                    ConsumeQuickSlotItem(index);
 
                 UsableItem.Use(heroT, useVec);
-                CoolTimeManager.Instance.AddCooltimeQueue(Item.getItemName,Item.getCoolTime);
-                if(Item.getClip != null)SoundManager.Instance.PlaySFX(Item.getClip,1.0f);
-                else Debug.Log("사운드 없음");
+
+                if (hasCoolTimeManager)
+                {
+                    CoolTimeManager.Instance.AddCooltimeQueue(Item.getItemName, Item.getCoolTime);
+                }
+
+                // 사운드 매니저 및 클립이 둘 다 유효할 때만 재생
+                if (Item.getClip != null && SoundManager.Instance != null)
+                {
+                    SoundManager.Instance.PlaySFX(Item.getClip, 1.0f);
+                }
+                else if (Item.getClip != null && SoundManager.Instance == null)
+                {
+                    Debug.LogWarning("[InventoryManager] SoundManager.Instance 가 null 입니다. 효과음을 재생할 수 없습니다.");
+                }
+                else
+                {
+                    Debug.Log("사운드 없음");
+                }
             }
             else
             {


### PR DESCRIPTION
## 🚀 Background
- 플레이 할 때 자연스러움을 위헤 공격방향으로 스프라이트 전환 기능 추가
- 인벤토리 디자인 수정

## 🥥 Changes
- 공격하는 방향으로 스프라이트 전환을 위해 스크립트 두개 추가
- HeroWeaponVisual
- HeroAttackFlash
<img width="156" height="174" alt="image" src="https://github.com/user-attachments/assets/44150cfc-136e-4919-8633-6e9e674474ea" />

Hero 하위 객체에 이미지들을 setVisible을 비활성화 상태로 추가

- HeroMove 코드를 수정에 해당방향 변수들 변경
 // 현재 바라보는 방향 벡터를 갱신
    void changeViewDirection(Vector2 inputDir)
    {
        if (inputDir.sqrMagnitude < 0.0001f) return; // 거의 0인 벡터는 무시
        Vector2 n = inputDir.normalized;
        if (currentViewDirection != n)
        {
            currentViewDirection = n;

            // 무기 방향 스프라이트도 함께 갱신
            if (weaponVisual != null)
            {
                weaponVisual.UpdateDirection(currentViewDirection);
            }
        }
    }

## 🪪 ID
- FR-033-1-1

## ⚓ Related Issue
- closes #162 
