### PR TITLE
[FR-LOGIC/fix/#200] 아이템 납입 점수 조정

### DIFF
--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -388,63 +388,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 23362122}
   m_CullTransparentMesh: 1
---- !u!1001 &31009490
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2176102489546224161, guid: ee7c374959315482480a927de829417b, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2176102489546224161, guid: ee7c374959315482480a927de829417b, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -5.28
-      objectReference: {fileID: 0}
-    - target: {fileID: 2176102489546224161, guid: ee7c374959315482480a927de829417b, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2176102489546224161, guid: ee7c374959315482480a927de829417b, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2176102489546224161, guid: ee7c374959315482480a927de829417b, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2176102489546224161, guid: ee7c374959315482480a927de829417b, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2176102489546224161, guid: ee7c374959315482480a927de829417b, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2176102489546224161, guid: ee7c374959315482480a927de829417b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2176102489546224161, guid: ee7c374959315482480a927de829417b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2176102489546224161, guid: ee7c374959315482480a927de829417b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7820732215765547225, guid: ee7c374959315482480a927de829417b, type: 3}
-      propertyPath: m_Name
-      value: RecipeNPC
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: ee7c374959315482480a927de829417b, type: 3}
 --- !u!114 &45804420 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3626232318315691473, guid: 136a1c324c1eb5946a440ea73dfe6188, type: 3}
@@ -78937,6 +78880,7 @@ MonoBehaviour:
   normalZombiePrefab: {fileID: 6989195092527803693, guid: 714bdc41231db45f1aa00d96ac6e3a4e, type: 3}
   highSpeedZombiePrefab: {fileID: 4821402263643920703, guid: 4a544aef09f203f468fbdba29f2cca98, type: 3}
   highPowerZombiePrefab: {fileID: 4017027571088634291, guid: d75f7e5c1222fd54ea400a87043586c4, type: 3}
+  defaultDayZombieCount: 60
   itemManager: {fileID: 600492179}
 --- !u!1 &720319382
 GameObject:
@@ -102055,63 +101999,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2065906912}
   m_CullTransparentMesh: 1
---- !u!1001 &2070058267
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 4375253768732716613, guid: 373950669bec64dc3885cb3428e01eee, type: 3}
-      propertyPath: m_Name
-      value: ExchangeNPC
-      objectReference: {fileID: 0}
-    - target: {fileID: 4454324047378695824, guid: 373950669bec64dc3885cb3428e01eee, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -1.13
-      objectReference: {fileID: 0}
-    - target: {fileID: 4454324047378695824, guid: 373950669bec64dc3885cb3428e01eee, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -5.13
-      objectReference: {fileID: 0}
-    - target: {fileID: 4454324047378695824, guid: 373950669bec64dc3885cb3428e01eee, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4454324047378695824, guid: 373950669bec64dc3885cb3428e01eee, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4454324047378695824, guid: 373950669bec64dc3885cb3428e01eee, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4454324047378695824, guid: 373950669bec64dc3885cb3428e01eee, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4454324047378695824, guid: 373950669bec64dc3885cb3428e01eee, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4454324047378695824, guid: 373950669bec64dc3885cb3428e01eee, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4454324047378695824, guid: 373950669bec64dc3885cb3428e01eee, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4454324047378695824, guid: 373950669bec64dc3885cb3428e01eee, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 373950669bec64dc3885cb3428e01eee, type: 3}
 --- !u!224 &2071541180 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3326755354662982724, guid: f5ec9b843b048934da309356f57fad2b, type: 3}
@@ -103395,5 +103282,3 @@ SceneRoots:
   - {fileID: 13734523}
   - {fileID: 206263455}
   - {fileID: 165715827}
-  - {fileID: 31009490}
-  - {fileID: 2070058267}

--- a/Assets/Scripts/Crafting/LampRecipe.asset
+++ b/Assets/Scripts/Crafting/LampRecipe.asset
@@ -17,8 +17,8 @@ MonoBehaviour:
     \uC544\uC774\uD15C\uC744 \uC815\uC758\uD569\uB2C8\uB2E4."
   requiredMaterials:
   - item: {fileID: -967469265316974195, guid: 636bd03e8d9f75c48a70e92071664bc9, type: 3}
-    amount: 1
+    amount: 4
   - item: {fileID: 8110723627053447128, guid: 5f3a59114b93870448531afcf21a3975, type: 3}
-    amount: 1
+    amount: 8
   resultItem: {fileID: -7234725743834073140, guid: 0a964f875a8e24d87ae5ea4b26ad8646, type: 3}
   resultCount: 1

--- a/Assets/Scripts/Crafting/ShoesRecipe.asset
+++ b/Assets/Scripts/Crafting/ShoesRecipe.asset
@@ -17,8 +17,8 @@ MonoBehaviour:
     \uC544\uC774\uD15C\uC744 \uC815\uC758\uD569\uB2C8\uB2E4."
   requiredMaterials:
   - item: {fileID: 871310912958583348, guid: b31846fef8942354c9e030b51adf3b25, type: 3}
-    amount: 1
+    amount: 8
   - item: {fileID: 8457254272999420636, guid: 425a1d701a7b0fe43b0e979d3247ac22, type: 3}
-    amount: 1
+    amount: 6
   resultItem: {fileID: 1522450408616026401, guid: 095e8605f1a843949a41d428d3fc0ac5, type: 3}
   resultCount: 1

--- a/Assets/Scripts/Item_cs/FoodItem/EnergeBar_401.asset
+++ b/Assets/Scripts/Item_cs/FoodItem/EnergeBar_401.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: EnergeBar_401
   m_EditorClassIdentifier: Assembly-CSharp::MedicineData
   ItemName: 401
-  Score: 5
+  Score: 4
   Description: "\uC5D0\uB108\uC9C0 \uBC14"
   Icon: {fileID: 0}
   MaxStackCount: 99

--- a/Assets/Scripts/Item_cs/HealItem/Antiseptic_201.asset
+++ b/Assets/Scripts/Item_cs/HealItem/Antiseptic_201.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Antiseptic_201
   m_EditorClassIdentifier: Assembly-CSharp::MedicineData
   ItemName: 201
-  Score: 5
+  Score: 3
   Description: "\uC18C\uB3C5\uC57D"
   Icon: {fileID: 2619156217251398772, guid: a4d9ddf8d7e6b0146a1fdbc0159db0f4, type: 3}
   MaxStackCount: 99

--- a/Assets/Scripts/Item_cs/HealItem/Emergency_food_204.asset
+++ b/Assets/Scripts/Item_cs/HealItem/Emergency_food_204.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Emergency_food_204
   m_EditorClassIdentifier: Assembly-CSharp::MedicineData
   ItemName: 204
-  Score: 15
+  Score: 4
   Description: "\uBE44\uC0C1 \uC2DD\uB7C9 \uD329"
   Icon: {fileID: 0}
   MaxStackCount: 99

--- a/Assets/Scripts/Item_cs/HealItem/FirstAidKit_203.asset
+++ b/Assets/Scripts/Item_cs/HealItem/FirstAidKit_203.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: FirstAidKit_203
   m_EditorClassIdentifier: Assembly-CSharp::MedicineData
   ItemName: 203
-  Score: 10
+  Score: 5
   Description: "\uC751\uAE09 \uAD6C\uAE09\uC0C1\uC790"
   Icon: {fileID: 0}
   MaxStackCount: 99

--- a/Assets/Scripts/Item_cs/HealItem/Painkiller_202.asset
+++ b/Assets/Scripts/Item_cs/HealItem/Painkiller_202.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Painkiller_202
   m_EditorClassIdentifier: Assembly-CSharp::MedicineData
   ItemName: 202
-  Score: 7
+  Score: 4
   Description: "\uC9C4\uD1B5\uC81C"
   Icon: {fileID: 4475158985010180414, guid: a4d9ddf8d7e6b0146a1fdbc0159db0f4, type: 3}
   MaxStackCount: 99

--- a/Assets/Scripts/Item_cs/SubmitItem/Battery_504.asset
+++ b/Assets/Scripts/Item_cs/SubmitItem/Battery_504.asset
@@ -19,3 +19,4 @@ MonoBehaviour:
   MaxStackCount: 0
   isAvailable: 0
   originCoolTime: 0
+  clip: {fileID: 0}

--- a/Assets/Scripts/Item_cs/SubmitItem/CanBundle_501.asset
+++ b/Assets/Scripts/Item_cs/SubmitItem/CanBundle_501.asset
@@ -13,8 +13,10 @@ MonoBehaviour:
   m_Name: CanBundle_501
   m_EditorClassIdentifier: Assembly-CSharp::SubmitData
   ItemName: 501
+  Score: 5
   Description: "\uD1B5\uC870\uB9BC \uBB36\uC74C"
   Icon: {fileID: 0}
   MaxStackCount: 99
   isAvailable: 0
-  coolTime: 0
+  originCoolTime: 0
+  clip: {fileID: 0}

--- a/Assets/Scripts/Item_cs/SubmitItem/Plate_502.asset
+++ b/Assets/Scripts/Item_cs/SubmitItem/Plate_502.asset
@@ -13,9 +13,10 @@ MonoBehaviour:
   m_Name: Plate_502
   m_EditorClassIdentifier: Assembly-CSharp::SubmitData
   ItemName: 502
-  Score: 1
+  Score: 3
   Description: "\uD2BC\uD2BC\uD55C \uD569\uD310"
   Icon: {fileID: 0}
   MaxStackCount: 0
   isAvailable: 0
   originCoolTime: 0
+  clip: {fileID: 0}

--- a/Assets/Scripts/Manager/DialogueManager.cs
+++ b/Assets/Scripts/Manager/DialogueManager.cs
@@ -12,7 +12,11 @@ public class DialogueManager : MonoBehaviour
 
     void Awake() 
     { 
-        Instance = this; 
+        // 싱글톤 패턴 보강 (선택적)
+        if (Instance == null)
+            Instance = this;
+        else if (Instance != this)
+            Destroy(gameObject);
     }
 
     public void StartDialogue(DialogueData data, DialogueNPC npc)
@@ -47,7 +51,7 @@ public class DialogueManager : MonoBehaviour
     }
 
     /// <summary>
-    /// 퀘스트 제출 UI를 띄우고 대화를 종료하는 함수
+    /// 퀘스트 제출 UI를 띄우고 대화를 일시 중단하는 함수 (EndDialogue 호출 안 함!)
     /// </summary>
     public void StartQuestSubmission(QuestData questData)
     {
@@ -61,6 +65,13 @@ public class DialogueManager : MonoBehaviour
             return;
         }
 
+        // 1. 대화 UI만 숨김 (대화 데이터는 유지)
+        if (DialogueUI.Instance != null)
+            DialogueUI.Instance.Hide(); 
+
+        // 2. 대화 상태를 '비활성'으로 전환 (UI가 보이지 않으므로)
+        IsDialogueActive = false;
+
         // 디버깅용: 현재 노드 정보 출력
         if (currentNodeIndex >= 0 && currentNodeIndex < currentData.nodes.Length)
         {
@@ -72,8 +83,7 @@ public class DialogueManager : MonoBehaviour
             Debug.LogWarning($"[DialogueManager] currentNodeIndex가 유효하지 않습니다: {currentNodeIndex}");
         }
 
-        EndDialogue();
-
+        // 3. 퀘스트 제출 UI를 띄울 때 돌아올 인덱스를 계산하여 전달
         int nextIndexAfterSubmission = 0;
         if (currentNodeIndex >= 0 && currentNodeIndex < currentData.nodes.Length)
             nextIndexAfterSubmission = currentData.nodes[currentNodeIndex].nextNodeIndex;
@@ -141,15 +151,18 @@ public class DialogueManager : MonoBehaviour
         if (DialogueUI.Instance != null)
             DialogueUI.Instance.Hide();
 
-        // currentData는 대화 재개를 위해 유지
+        // 대화가 완전히 끝났으므로 모든 상태 초기화
+        currentData = null; // 대화 데이터 초기화
+        currentNodeIndex = -1;
 
         if (currentNPC != null)
         {
-            currentNPC.OnDialogueEnd();
+            currentNPC.OnDialogueEnd(); // NPC에게 종료 알림
             currentNPC = null;
         }
 
         IsDialogueActive = false;
         GameManager.Instance?.EndInteraction();
+        Debug.Log("[DialogueManager] 대화 상태 완전 초기화 완료.");
     }
 }

--- a/Assets/Scripts/Manager/GameManager.cs
+++ b/Assets/Scripts/Manager/GameManager.cs
@@ -485,7 +485,7 @@ void StartNightPhase()
     }
 
 // TODO: 일차별 랜덤 납입품 목록 생성
-// MARK: 일차별 랜덤 납입품 목록 생성 로직 (수정됨: 종류 최소 3종 ~ 최대 6종, 수량 최대 5개 제한)
+// MARK: 일차별 랜덤 납입품 목록 생성 로직 (수정됨: 종류 최소 3종 ~ 최대 6종, 수량 20개~33개 이내)
     void GenerateRequiredItems()
     {
         CurrentRequiredItemsData.Clear(); 
@@ -497,11 +497,12 @@ void StartNightPhase()
             return;
         }
 
+        // 목표 점수는 100점이라고 가정합니다.
         int currentTargetScore = TargetRequiredScore; 
         
-        // 1. 요구 아이템 종류 최소/최대 설정 (최소 5종, 최대 8종)
-        const int MIN_REQUIRED_ITEMS = 5; 
-        const int MAX_REQUIRED_ITEMS = 9;
+        // 1. 요구 아이템 종류 최소/최대 설정 (최소 3종, 최대 6종)
+        const int MIN_REQUIRED_ITEMS = 3; 
+        const int MAX_REQUIRED_ITEMS = 6;
         
         // 2. 가중치 풀 생성 (실제 아이템 점수 사용)
         List<(Item item, int score, float weight)> weightedPool = new List<(Item, int, float)>();
@@ -509,12 +510,20 @@ void StartNightPhase()
 
         foreach (Item item in AvailableSubmitItems)
         {
-            // ItemDataAsset이 없으므로, 임시로 모든 아이템의 점수를 10점으로 가정합니다.
-            int score = 10; 
+            // ⭐ [수정 필요] ItemDataAsset이 없으므로, 여기서 실제 아이템의 납입 점수를 가져와야 합니다.
+            // 임시로 Item 객체에 public int SubmitScore 필드가 있다고 가정하고 3~5점 범위에서 값을 가져옵니다.
+            int score;
             
+            // 💡 Item 객체에 SubmitScore 필드가 있다고 가정합니다. (실제 프로젝트에 맞게 수정 필요)
+            // score = item.SubmitScore; 
+            
+            // 임시로 3점에서 5점 사이의 랜덤 값을 사용 (실제 데이터에 맞게 수정 필요)
+            score = Random.Range(3, 6); // 3, 4, 5 중 하나
+
             if (score <= 0) continue; 
 
-            // 점수가 높을수록 가중치를 낮춥니다. (점수가 10점으로 고정되었으므로 가중치도 고정)
+            // 점수가 높을수록 가중치를 낮춥니다. (저가치 아이템이 더 자주 선택됨)
+            // 3~5점 범위이므로 평균 요구 수량은 20~33개가 됩니다.
             float weight = 100f / (float)score; 
             weightedPool.Add((item, score, weight));
             totalWeight += weight;
@@ -522,28 +531,26 @@ void StartNightPhase()
         
         int availableUniqueItems = weightedPool.Count;
 
-        // 유효 아이템 개수가 최소 요구치(3개)보다 적으면 경고
+        // 유효 아이템 개수 검증 (3개 미만 경고 로직 유지)
         if (availableUniqueItems < MIN_REQUIRED_ITEMS)
         {
             Debug.LogWarning($"[GameManager] 유효한 납입 아이템이 {availableUniqueItems}개 밖에 없어 {MIN_REQUIRED_ITEMS}개 이상 요구할 수 없습니다. 가능한 모든 ({availableUniqueItems}개) 아이템을 요구합니다.");
         }
         
-        // 실제로 요구할 아이템 종류 개수 결정 (풀 개수와 MAX/MIN 요구 개수를 모두 고려)
+        // 실제로 요구할 아이템 종류 개수 결정 로직 유지
         int maxItemsToRequire = Mathf.Min(MAX_REQUIRED_ITEMS, availableUniqueItems);
         int requiredItemCount = Random.Range(Mathf.Min(MIN_REQUIRED_ITEMS, maxItemsToRequire), maxItemsToRequire + 1);
 
         if (requiredItemCount == 0 && availableUniqueItems > 0) 
         {
-             // 혹시 3개 미만인 풀에서 Range가 0을 반환하지 않도록 최소 1개는 요구하도록 보장
             requiredItemCount = 1; 
         }
 
         if (requiredItemCount == 0) return; // 요구할 아이템이 없으면 종료
 
-        // 3. 가중치 기반 아이템 무작위 선택
+        // 3. 가중치 기반 아이템 무작위 선택 로직 유지
         List<(Item item, int score)> selectedItemsWithScore = new List<(Item, int)>();
         
-        // requiredItemCount 횟수만큼 반복하여 아이템을 선택
         for (int i = 0; i < requiredItemCount; i++)
         {
             float randomValue = Random.Range(0f, totalWeight);
@@ -564,17 +571,15 @@ void StartNightPhase()
                 }
             }
             
-            // 만약 선택 가능한 아이템이 없거나 (totalWeight=0) 루프가 끝났다면 종료
             if (selectedItem == null) break;
             
             selectedItemsWithScore.Add((selectedItem, selectedScore));
             
-            // 선택된 아이템은 풀에서 제거하고 가중치도 갱신합니다.
             totalWeight -= weightedPool[selectedIndex].weight;
             weightedPool.RemoveAt(selectedIndex);
         }
         
-        // 4. 점수 할당 및 수량 계산 (수량 최대 5개 이하로 제한)
+        // 4. 점수 할당 및 수량 계산 (총합 100점 보장)
         int actualSelectedCount = selectedItemsWithScore.Count;
         
         if (actualSelectedCount == 0)
@@ -589,6 +594,7 @@ void StartNightPhase()
         int minTotalScoreNeeded = actualSelectedCount; 
         if (remainingScore < minTotalScoreNeeded) remainingScore = minTotalScoreNeeded;
 
+        // 남은 점수를 분배 (각 아이템에 최소 1점 할당)
         for (int i = 0; i < actualSelectedCount - 1; i++)
         {
             int minScore = 1;
@@ -599,40 +605,35 @@ void StartNightPhase()
             scoreAllocations.Add(allocatedScore);
             remainingScore -= allocatedScore;
         }
-        scoreAllocations.Add(remainingScore); 
+        scoreAllocations.Add(remainingScore); // 마지막 아이템에 남은 점수 전부 할당
         
         int actualTotalRequiredScore = 0;
         
-        // 최종 수량 계산
+        // 최종 수량 계산 (클램프 제거로 100점 보장)
         for (int i = 0; i < selectedItemsWithScore.Count; i++)
         {
             var (item, itemUnitScore) = selectedItemsWithScore[i];
             int requiredScorePortion = scoreAllocations[i];
             
-            // 요구 수량 계산
+            // 요구 수량 계산: requiredCount는 ceilToInt 덕분에 항상 정수이며, 
+            // requiredCount * itemUnitScore >= requiredScorePortion을 만족합니다.
             int requiredCount = Mathf.CeilToInt((float)requiredScorePortion / itemUnitScore);
             
-            int preClampCount = requiredCount; 
-            // ⭐ [수정] 요구 수량 제한을 1개 이상, 5개 이하로 변경합니다.
-            requiredCount = Mathf.Clamp(requiredCount, 7, 12); 
-            
-            if (preClampCount > requiredCount) // 5개를 초과한 경우 경고
-            {
-                string itemName = (item != null) ? item.itemName : "Unknown Item";
-                
-                Debug.LogWarning($"[GameManager] 아이템: {itemName}, 단위 점수: {itemUnitScore}. 할당 점수: {requiredScorePortion}. " +
-                                 $"계산된 수량: {preClampCount} -> ⭐ {requiredCount}개로 강제 제한됨!");
-            }
+            // ⭐ [수정] 수량 제한 클램프를 제거합니다. 
+            // 20~33개 목표는 3~5점 밸런싱과 가중치로 달성됩니다.
             
             CurrentRequiredItemsData.Add(item, requiredCount);
             CurrentSubmittedData.Add(item, 0); 
 
-            actualTotalRequiredScore += requiredCount * itemUnitScore;
+            // 실제 합산 점수는 requiredScorePortion과 같거나 약간 높습니다 (CeilToInt 사용 시)
+            // ex: 5점짜리에 9점 할당 -> ceil(9/5) = 2개 요구 -> 실제 점수 10점
+            actualTotalRequiredScore += requiredCount * itemUnitScore; 
         }
 
         Debug.Log($"[GameManager] {GetDayString(CurrentDay)} 납입 요구 목록 생성. 목표 점수: {currentTargetScore}, 실제 요구 점수 합산: {actualTotalRequiredScore}. (총 {CurrentRequiredItemsData.Count}종)");
     }
 
+    
     // MARK: 다음 날로 전환
     IEnumerator NextDayCoroutine()
     {

--- a/Assets/Scripts/Manager/GameManager.cs
+++ b/Assets/Scripts/Manager/GameManager.cs
@@ -501,7 +501,7 @@ void StartNightPhase()
         
         // 1. 요구 아이템 종류 최소/최대 설정 (최소 5종, 최대 8종)
         const int MIN_REQUIRED_ITEMS = 5; 
-        const int MAX_REQUIRED_ITEMS = 8;
+        const int MAX_REQUIRED_ITEMS = 9;
         
         // 2. 가중치 풀 생성 (실제 아이템 점수 사용)
         List<(Item item, int score, float weight)> weightedPool = new List<(Item, int, float)>();
@@ -614,7 +614,7 @@ void StartNightPhase()
             
             int preClampCount = requiredCount; 
             // ⭐ [수정] 요구 수량 제한을 1개 이상, 5개 이하로 변경합니다.
-            requiredCount = Mathf.Clamp(requiredCount, 7, 10); 
+            requiredCount = Mathf.Clamp(requiredCount, 7, 12); 
             
             if (preClampCount > requiredCount) // 5개를 초과한 경우 경고
             {

--- a/Assets/Scripts/Manager/QuestManager.cs
+++ b/Assets/Scripts/Manager/QuestManager.cs
@@ -16,7 +16,8 @@ public class QuestManager : MonoBehaviour
     public Image requiredItemImageComponent;
     public Text submitAmountText;
     public Button submitButton;
-    public QuestSlot questDropSlot;
+    // QuestSlot 클래스가 Item 타입의 RewardItem과 int 타입의 RewardCount 필드를 가지고 있다고 가정
+    public QuestSlot questDropSlot; 
     
     private QuestData activeQuestData;
     private int nextDialogueNodeIndex = -1;
@@ -35,7 +36,7 @@ public class QuestManager : MonoBehaviour
     }
 
     // ───────────────────────────────
-    // OpenSubmitUI: UI 열기 (✅ 인벤토리 열기 로직 추가)
+    // OpenSubmitUI: UI 열기
     public void OpenSubmitUI(QuestData data, int nextIndex)
     {
         Debug.Log($"[OpenSubmitUI] 호출: data={(data != null ? data.questName : "null")}, nextIndex={nextIndex}");
@@ -56,7 +57,6 @@ public class QuestManager : MonoBehaviour
         if (submitAmountText != null)
         {
             submitAmountText.gameObject.SetActive(true);
-            // submittedCount와 RequiredAmount를 QuestSlot에서 가져온다고 가정
             int submitted = questDropSlot != null ? questDropSlot.submittedCount : 0;
             int required = questDropSlot != null ? questDropSlot.RequiredAmount : 0;
             submitAmountText.text = $"수량: {submitted} / {required}";
@@ -76,21 +76,17 @@ public class QuestManager : MonoBehaviour
             submitButton.gameObject.SetActive(true);
         }
 
-        // 1. SubmitCanvas 활성화
-        if (submitCanvas != null)
-            submitCanvas.SetActive(true);
-
-        // 2. QuestPanel 활성화
-        if (QuestPanel != null)
-            QuestPanel.SetActive(true);
+        // 1. SubmitCanvas 및 패널 활성화
+        if (submitCanvas != null) submitCanvas.SetActive(true);
+        if (QuestPanel != null) QuestPanel.SetActive(true);
         
-        // 3. SubmitImagePanel 활성화 (✅ 핵심: 콘텐츠가 보이도록 함)
+        // 3. SubmitImagePanel 활성화
         if (submitImagePanel != null)
             submitImagePanel.SetActive(true);
         else
             Debug.LogError("[QuestManager] SubmitImagePanel이 Inspector에 연결되지 않았습니다. UI 콘텐츠가 보이지 않습니다.");
 
-        // 4. ✅ 인벤토리 UI 활성화 (퀘스트 납입 시 인벤토리 열기)
+        // 4. 인벤토리 UI 활성화 
         if (InventoryUI.instance != null) 
         {
             InventoryUI.instance.OpenInventory();
@@ -104,114 +100,187 @@ public class QuestManager : MonoBehaviour
         Debug.Log("[OpenSubmitUI] UI 열림 완료");
     }
 
-    // ───────────────────────────────
-    // 제출 버튼
-    public void OnSubmitButtonClicked()
+// ───────────────────────────────
+// 제출 버튼 클릭
+public void OnSubmitButtonClicked()
+{
+    // (줄 110)
+    if (activeQuestData == null)
     {
-        if (activeQuestData == null || questDropSlot == null) return;
-
-        // ConfirmSubmission이 성공적으로 아이템 소모 및 카운트 증가 처리 후 true를 반환한다고 가정
-        if (questDropSlot.ConfirmSubmission())
-        {
-            Debug.Log("[OnSubmitButtonClicked] 아이템 제출 성공");
-            // 아이템 제출 후 OnItemSubmitted 로직이 실행되어 퀘스트 완료 여부를 판단해야 함
-            // OnItemSubmitted(activeQuestData.requiredItemName, submittedAmount, questDropSlot);
-        }
+        Debug.LogWarning("[QuestManager] OnSubmitButtonClicked: activeQuestData가 Null입니다. 제출 중단.");
+        return;
     }
     
-    // ───────────────────────────────
-    // 아이템 제출 시 (QuestSlot 또는 Inventory 시스템에서 호출된다고 가정)
-    public void OnItemSubmitted(string itemName, int amountSubmitted, QuestSlot slot)
+    // 1. 초기 Null 체크
+    if (questDropSlot == null)
     {
-        if (slot.submittedCount >= slot.RequiredAmount)
+        Debug.LogError("[QuestManager] OnSubmitButtonClicked: questDropSlot 참조가 Null입니다! Inspector 연결 확인.");
+        return;
+    }
+
+    bool confirmed = questDropSlot.ConfirmSubmission(); // (A) ConfirmSubmission 호출
+    
+    // 2. ConfirmSubmission() 호출 후, QuestSlot이 혹시 파괴되었는지 재확인 (방어 코드)
+    if (questDropSlot == null) 
+    {
+         Debug.LogError("[QuestManager] ConfirmSubmission 호출 후 QuestSlot이 파괴되었습니다. CloseSubmitUI 호출 시점을 확인하십시오.");
+         return;
+    }
+
+    if (confirmed)
+    {
+        Debug.Log("[OnSubmitButtonClicked] 아이템 제출 성공 - ConfirmSubmission() 성공.");
+        
+        // 퀘스트 슬롯의 상태를 다시 확인하여 완료 여부 판단
+        if (questDropSlot.submittedCount >= questDropSlot.RequiredAmount)
         {
-            Debug.Log($"[OnItemSubmitted] 퀘스트 '{activeQuestData.questName}' 완료!");
-            HandleQuestCompletion(slot);
-            CloseSubmitUI(); // 완료 후 자동으로 UI 닫기
+            //  Debug.Log($"[OnSubmitButtonClicked] 퀘스트 '{activeQuestData.questName}' 완료!");
+             HandleQuestCompletion(questDropSlot);
+             
+             // 💡 퀘스트 완료 후, 대화 재개 로직이 끝난 후 UI를 닫습니다.
+             // OnItemSubmitted에서 CloseSubmitUI를 제거했으므로 여기서 닫아줍니다.
+             CloseSubmitUI(); 
         }
         else
         {
-            if (submitAmountText != null)
-                submitAmountText.text = $"수량: {slot.submittedCount} / {slot.RequiredAmount}";
+             if (submitAmountText != null)
+                submitAmountText.text = $"수량: {questDropSlot.submittedCount} / {questDropSlot.RequiredAmount}";
+        }
+    }
+}
+    
+// ───────────────────────────────
+// 아이템 제출 시 (QuestSlot에서 호출)
+public void OnItemSubmitted(string itemName, int amountSubmitted, QuestSlot slot)
+{
+    // 여기서 CloseSubmitUI() 호출을 제거합니다. (OnSubmitButtonClicked에서 최종 처리)
+    if (slot.submittedCount >= slot.RequiredAmount)
+    {
+        Debug.Log($"[OnItemSubmitted] 퀘스트 '{activeQuestData.questName}' 완료!");
+        HandleQuestCompletion(slot);
+    }
+    else
+    {
+        if (submitAmountText != null)
+            submitAmountText.text = $"수량: {slot.submittedCount} / {slot.RequiredAmount}";
+    }
+}
+
+// ───────────────────────────────
+// UI 닫기 (X 버튼 클릭 또는 완료 후 호출)
+
+public void CloseSubmitUI()
+{
+    Debug.Log("[CloseSubmitUI] 호출됨. 제출 UI와 대화 상태 정리 시작.");
+
+    // 💡 퀘스트가 완료되지 않은 상태에서 UI를 닫을 경우에만 DialogueManager를 정리합니다.
+    if (activeQuestData != null) // 퀘스트 미완료 상태 (activeQuestData가 아직 null로 설정되지 않음)
+    {
+        if (DialogueManager.Instance != null)
+        {
+            DialogueManager.Instance.EndDialogue();
+            Debug.Log("[CloseSubmitUI] 퀘스트 미완료 상태에서 UI 닫힘: DialogueManager.EndDialogue() 호출.");
+        } else {
+             Debug.LogError("[CloseSubmitUI Error] DialogueManager.Instance가 Null입니다!");
         }
     }
 
-    // ───────────────────────────────
-    /// <summary>
-    /// UI 닫기 (X 버튼 클릭 또는 완료 후 호출) (✅ 인벤토리 닫기 로직 추가)
-    /// </summary>
-    public void CloseSubmitUI()
+    // GameManager Null 체크 강화
+    if (GameManager.Instance != null)
     {
-        Debug.Log("[CloseSubmitUI] 호출됨. 제출 UI와 대화 상태 정리 시작.");
-
-        // DialogueManager 상태 강제 종료 (대화 재개 문제 해결 로직)
-        if (DialogueManager.Instance != null && DialogueManager.Instance.IsDialogueActive)
-        {
-            // DialogueManager의 EndDialogue()를 호출하여 currentNPC, IsDialogueActive 등을 정리
-            DialogueManager.Instance.EndDialogue(); 
-            Debug.Log("[CloseSubmitUI] DialogueManager 상태 강제 종료 처리 완료.");
-        }
-
-        GameManager.Instance?.EndInteraction();
+        GameManager.Instance.EndInteraction();
         Debug.Log("[CloseSubmitUI] GameManager.EndInteraction() 호출 완료.");
-
-        // 4. ✅ 인벤토리 UI 비활성화
-        if (InventoryUI.instance != null) 
-        {
-            InventoryUI.instance.CloseInventory();
-            Debug.Log("[CloseSubmitUI] 인벤토리 UI를 닫았습니다.");
-        }
-
-        // 1. SubmitImagePanel 비활성화
-        if (submitImagePanel != null)
-            submitImagePanel.SetActive(false);
-        
-        // 2. QuestPanel 비활성화
-        if (QuestPanel != null)
-            QuestPanel.SetActive(false);
-        
-        // 3. SubmitCanvas 비활성화
-        if (submitCanvas != null) 
-            submitCanvas.SetActive(false); 
-            
-        if (requiredItemImageComponent != null) requiredItemImageComponent.enabled = false;
-        if (questDropSlot != null)
-        {
-            questDropSlot.ResetSlot();
-            questDropSlot.gameObject.SetActive(false); // 슬롯 오브젝트도 명시적으로 끔
-        }
-
-        activeQuestData = null;
-        nextDialogueNodeIndex = -1;
-
-        Debug.Log("[CloseSubmitUI] 상태 초기화 완료");
+    } else {
+         Debug.LogWarning("[CloseSubmitUI] GameManager.Instance가 Null이므로 EndInteraction을 건너뜁니다.");
     }
 
-    // ───────────────────────────────
-    // 퀘스트 완료 처리
-    private void HandleQuestCompletion(QuestSlot slot)
+    // 4. 인벤토리 UI 비활성화
+    if (InventoryUI.instance != null) 
     {
-        Debug.Log($"[HandleQuestCompletion] 보상 지급 시작");
+        InventoryUI.instance.CloseInventory();
+        Debug.Log("[CloseSubmitUI] 인벤토리 UI를 닫았습니다.");
+    } else {
+         Debug.LogWarning("[CloseSubmitUI] InventoryUI.instance가 Null이므로 인벤토리 닫기를 건너뜁니다.");
+    }
+    
+    // 1~3. UI 비활성화
+    if (submitImagePanel != null) submitImagePanel.SetActive(false);
+    if (QuestPanel != null) QuestPanel.SetActive(false);
+    
+    // **가장 상위 Canvas를 끄는 것이 핵심입니다.**
+    if (submitCanvas != null) {
+        submitCanvas.SetActive(false); 
+        Debug.Log("[CloseSubmitUI] SubmitCanvas 비활성화 완료.");
+    } else {
+        Debug.LogError("[CloseSubmitUI] submitCanvas가 Null입니다! UI가 닫히지 않는 근본 원인일 수 있습니다. Inspector를 확인하세요.");
+    }
+        
+    if (requiredItemImageComponent != null) requiredItemImageComponent.enabled = false;
+    if (questDropSlot != null)
+    {
+        questDropSlot.ResetSlot();
+        questDropSlot.gameObject.SetActive(false); 
+    }
+    
+    // ⭐⭐⭐ 핵심 수정: 버튼 리스너 명시적 제거 ⭐⭐⭐
+    if (submitButton != null)
+    {
+        submitButton.onClick.RemoveAllListeners();
+        Debug.Log("[CloseSubmitUI] SubmitButton 리스너를 모두 제거했습니다.");
+    }
+    // ⭐⭐⭐⭐⭐⭐⭐⭐⭐⭐⭐⭐⭐⭐⭐⭐⭐⭐⭐⭐⭐⭐⭐
 
-        // 보상 지급 로직 (Inventory 클래스가 존재한다고 가정)
-        if (slot.RewardItem != null && Inventory.instance != null)
+    activeQuestData = null; // UI가 닫힐 때 완전히 초기화
+    nextDialogueNodeIndex = -1;
+
+    Debug.Log("[CloseSubmitUI] 상태 초기화 완료");
+}
+
+// ───────────────────────────────
+// 퀘스트 완료 처리
+private void HandleQuestCompletion(QuestSlot slot)
+{
+    Debug.Log($"[HandleQuestCompletion] 보상 지급 시작");
+
+    // 1. 보상 지급 로직
+    if (slot.RewardItem != null)
+    {
+        if (Inventory.instance != null)
         {
             Inventory.instance.AddItem(slot.RewardItem, slot.RewardCount);
-            Debug.Log($"[HandleQuestCompletion] 보상: {slot.RewardItem.itemName} x{slot.RewardCount}");
+            Debug.Log($"[HandleQuestCompletion] 보상 지급 완료: {slot.RewardItem.itemName} x{slot.RewardCount}");
         }
+        else
+        {
+             Debug.LogError("[HandleQuestCompletion Error] Inventory.instance가 Null입니다! 보상 지급 실패.");
+        }
+    }
+    else
+    {
+         Debug.Log("[HandleQuestCompletion] 지급할 보상 아이템이 없습니다.");
+    }
 
-        // 대화 재개 (성공 시)
-        if (DialogueManager.Instance != null && nextDialogueNodeIndex != -1)
+
+    // 2. 대화 재개 (성공 시)
+    if (nextDialogueNodeIndex != -1)
+    {
+        if (DialogueManager.Instance != null)
         {
             DialogueManager.Instance.ContinueDialogueAtNode(nextDialogueNodeIndex);
             Debug.Log($"[HandleQuestCompletion] 다음 노드 진행: {nextDialogueNodeIndex}");
-        } else
+        } 
+        else
         {
-            
+             Debug.LogError("[HandleQuestCompletion Error] DialogueManager.Instance가 Null입니다! 대화 재개 생략.");
         }
-
-        activeQuestData = null;
-        nextDialogueNodeIndex = -1;
-        Debug.Log("[HandleQuestCompletion] 상태 초기화 완료");
+    } 
+    else
+    {
+         Debug.LogWarning("[HandleQuestCompletion] 다음 노드 인덱스가 없습니다. 대화 재개 생략.");
     }
+
+    activeQuestData = null; // 완료 후 activeQuestData를 null로 설정
+    nextDialogueNodeIndex = -1;
+    Debug.Log("[HandleQuestCompletion] 상태 초기화 완료");
+}
 }

--- a/Assets/Scripts/Quest/ExchangeQuestData/Exchage1.asset
+++ b/Assets/Scripts/Quest/ExchangeQuestData/Exchage1.asset
@@ -17,6 +17,6 @@ MonoBehaviour:
     \uC124\uC815\uB429\uB2C8\uB2E4."
   requiredItemName: Can
   requiredItemIcon: {fileID: 7032184553362833509, guid: 38c3d8231c4eb73478464217531b4925, type: 3}
-  requiredAmount: 1
+  requiredAmount: 2
   rewardItem: {fileID: -5984088972931491910, guid: 5d9a4a6bb9122432497b32b9a6cdd7e4, type: 3}
-  rewardCount: 1
+  rewardCount: 2

--- a/Assets/Scripts/Quest/QuestSlot.cs
+++ b/Assets/Scripts/Quest/QuestSlot.cs
@@ -127,64 +127,72 @@ public class QuestSlot : Slot
     }
     
     /// <summary>
-    /// 버튼이 눌렸을 때 임시 배치된 아이템을 확정 제출하는 함수 (QuestManager에서 호출됨)
-    /// </summary>
-    public bool ConfirmSubmission()
+/// 버튼이 눌렸을 때 임시 배치된 아이템을 확정 제출하는 함수 (QuestManager에서 호출됨)
+/// </summary>
+public bool ConfirmSubmission()
+{
+    if (temporaryItem == null || temporaryItemIndex == -1)
     {
-        if (temporaryItem == null || temporaryItemIndex == -1)
-        {
-            Debug.LogWarning("[Quest] 슬롯에 납입할 아이템이 없습니다.");
-            return false;
-        }
-        
-        Inventory inven = Inventory.instance;
-        if (inven == null) 
-        {
-            Debug.LogError("[QuestSlot] Inventory.instance가 null입니다.");
-            ClearTemporarySlot();
-            return false;
-        }
-        
-        // 인벤토리에서 실제 아이템 확인 (드래그 후 인벤토리 변경이 발생했을 수 있으므로 재확인)
-        InventoryItem actualItem = inven.items[temporaryItemIndex];
-        if (actualItem == null || actualItem.itemName != requiredItemName)
-        {
-            Debug.LogError("[Quest] 인벤토리에서 아이템을 찾을 수 없거나 아이템이 변경되었습니다.");
-            ClearTemporarySlot(); 
-            return false;
-        }
-        
-        int needed = requiredAmount - submittedCount; 
-        if (needed <= 0)
-        {
-            Debug.Log($"[Quest] {requiredItemName}은 이미 충분히 제출되었습니다.");
-            ClearTemporarySlot(); 
-            return true; // 이미 완료된 것으로 간주
-        }
-        
-        // 필요한 수량과 인벤토리의 실제 수량 중 작은 값만큼 제출
-        int submitAmount = Mathf.Min(needed, actualItem.count);
-        
-        // 인벤토리에서 아이템 소모
-        inven.ConsumeItemAt(temporaryItemIndex, submitAmount);
-        submittedCount += submitAmount;
-        
-        // UI 업데이트
-        UpdateQuestSlotUI(temporaryItem); 
-        
-        // ⭐ QuestManager에게 제출 완료 알림 (보상 지급 트리거)
-        // QuestManager.instance는 외부에서 참조 가능하다고 가정합니다.
-        if (QuestManager.instance != null)
-        {
-            QuestManager.instance.OnItemSubmitted(requiredItemName, submitAmount, this);
-        }
-        
-        ClearTemporarySlot(); // 임시 배치 상태 해제
-        
-        Debug.Log($"아이템 {requiredItemName} {submitAmount}개를 확정 납입했습니다. (총 {submittedCount}/{requiredAmount})");
-        return true;
+        Debug.LogWarning("[Quest] 슬롯에 납입할 아이템이 없습니다.");
+        return false;
     }
+    
+    Inventory inven = Inventory.instance;
+    if (inven == null) 
+    {
+        Debug.LogError("[QuestSlot] Inventory.instance가 null입니다.");
+        ClearTemporarySlot();
+        return false;
+    }
+    
+    // 인벤토리에서 실제 아이템 확인 (드래그 후 인벤토리 변경이 발생했을 수 있으므로 재확인)
+    InventoryItem actualItem = inven.items[temporaryItemIndex];
+    if (actualItem == null || actualItem.itemName != requiredItemName)
+    {
+        Debug.LogError("[Quest] 인벤토리에서 아이템을 찾을 수 없거나 아이템이 변경되었습니다.");
+        ClearTemporarySlot(); 
+        return false;
+    }
+    
+    int needed = requiredAmount - submittedCount; 
+    if (needed <= 0)
+    {
+        Debug.Log($"[Quest] {requiredItemName}은 이미 충분히 제출되었습니다.");
+        ClearTemporarySlot(); 
+        return true; // 이미 완료된 것으로 간주
+    }
+    
+    // 필요한 수량과 인벤토리의 실제 수량 중 작은 값만큼 제출
+    int submitAmount = Mathf.Min(needed, actualItem.count);
+    
+    // 인벤토리에서 아이템 소모
+    inven.ConsumeItemAt(temporaryItemIndex, submitAmount);
+    submittedCount += submitAmount;
+    
+    // UI 업데이트
+    UpdateQuestSlotUI(temporaryItem); 
+    
+    // ⭐ QuestManager에게 제출 완료 알림 (보상 지급 트리거)
+    if (QuestManager.instance != null)
+    {
+        // 이 함수 호출 후 QuestSlot 오브젝트가 파괴되는지 확인이 필요합니다.
+        QuestManager.instance.OnItemSubmitted(requiredItemName, submitAmount, this); 
+    }
+    
+    ClearTemporarySlot(); // 임시 배치 상태 해제
+    
+    Debug.Log($"아이템 {requiredItemName} {submitAmount}개를 확정 납입했습니다. (총 {submittedCount}/{requiredAmount})");
 
+    // 👇👇👇 중요: 여기서 파괴 여부 확인 👇👇👇
+    if (this.gameObject == null)
+    {
+        // 이 로그가 출력되면 QuestManager.OnItemSubmitted 또는 그 외부에 의해 객체가 파괴된 것입니다.
+        Debug.LogError("[QuestSlot] FATAL: ConfirmSubmission이 반환되기 직전에 오브젝트가 파괴되었습니다!"); 
+    }
+    // 👆👆👆 중요: 여기서 파괴 여부 확인 👆👆👆
+    
+    return true;
+}
 
     // 임시 배치된 아이템의 정보(개수)를 보여주는 UI 업데이트
     private void UpdateTemporarySlotUI(InventoryItem itemData)


### PR DESCRIPTION
## 🚀 Background
- 납입품 리스트 총합을 설정하기 위한 아이템별 납입 점수 조정

## 🥥 Changes
분류 | 아이템명 | 최종 납입 점수 (3~5점) | 최종 요구 수량 예측
-- | -- | -- | --
의료용 | 붕대 | 3 | 총 33개 이하
의료용 | 소독약 | 3 |  
의료용 | 진통제 | 4 |  
의료용 | 응급 구급상자 | 5 |  
의료용 | 비상 식량 팩 | 4 |  
쉘터 납입품 | 튼튼한 합판 | 3 |  
쉘터 납입품 | 통조림 묶음 | 5 |  
쉘터 납입품 | 배터리 | 3 |  
플레이어 | 생수 | 3 |  
플레이어 | 에너지바 | 4 |  
플레이어 | 통조림 캔 | 5 |  

## 🪪 ID
- FR-012-1-3

## ⚓ Related Issue
- closes #200
