### PR TITLE
[FR-LOGIC/fix/#218] 퀘스트 오류 수정 및 쉘터 출입 시 페이즈 밝기 오류 수정

### DIFF
--- a/Assets/Scripts/Controller/LightController.cs
+++ b/Assets/Scripts/Controller/LightController.cs
@@ -63,9 +63,11 @@ public class LightController : MonoBehaviour
     {
         if (globalLight == null) return;
         
+        // ⭐ 개선: 새로운 코루틴 시작 전에 기존 코루틴을 중지하고 null로 설정
         if (lightCoroutine != null)
         {
             StopCoroutine(lightCoroutine);
+            lightCoroutine = null; 
         }
 
         if (newPhase == Phase.Night)
@@ -105,9 +107,7 @@ public class LightController : MonoBehaviour
     // MARK: 밤 -> 낮 (일출) 복합 전환 시퀀스
     private IEnumerator TransitionNightToDayComplexSequence()
     {
-        // 1. **(수정 적용)** 4초 동안 서서히 밝아짐 (현재 밤색 -> 붉은 새벽 Dawn 색상)
-        // Night 상태에서 Dawn 상태로 바로 부드럽게 전환합니다.
-        // transitionDuration을 4f로 설정하여 사용합니다.
+        // 1. 4초 동안 서서히 밝아짐 (현재 밤색 -> 붉은 새벽 Dawn 색상)
         yield return TransitionLight(dawnIntensity, dawnColor, transitionDuration);
         
         // 2. 10초 동안 붉은 새벽 상태 유지
@@ -116,6 +116,7 @@ public class LightController : MonoBehaviour
         // 3. 5초 동안 서서히 완전한 낮 (MidDay)으로 전환
         yield return TransitionLight(midDayIntensity, midDayColor, dawnToMidDayTransitionDuration);
         
+        // ⭐ 개선: 코루틴이 자연스럽게 종료될 때 null로 설정
         lightCoroutine = null;
     }
     
@@ -126,9 +127,37 @@ public class LightController : MonoBehaviour
         yield return TransitionLight(duskIntensity, duskColor, midDayToDuskTransitionDuration);
 
         // 2. 4초 동안 서서히 짙은 밤 (Night)으로 전환
-        // transitionDuration을 4f로 설정하여 사용합니다.
         yield return TransitionLight(nightIntensity, nightColor, transitionDuration);
         
+        // ⭐ 개선: 코루틴이 자연스럽게 종료될 때 null로 설정
         lightCoroutine = null;
+    }
+
+    // MARK: 씬 로드 시 즉시 조명 설정
+    public void SetGlobalLightInstantly(Phase phase)
+    {
+        if (globalLight == null) return;
+        
+        // ⭐ 이 로직은 이미 정확합니다. 모든 전환을 멈춥니다.
+        if (lightCoroutine != null)
+        {
+            StopCoroutine(lightCoroutine);
+            lightCoroutine = null;
+        }
+
+        if (phase == Phase.Night)
+        {
+            // 밤의 최종 목표 값으로 즉시 설정
+            globalLight.intensity = nightIntensity;
+            globalLight.color = nightColor;
+            Debug.Log("[LightController] 씬 로드: 밤 상태로 조명 즉시 설정 완료.");
+        }
+        else // Phase.Day
+        {
+            // 낮의 최종 목표 값으로 즉시 설정
+            globalLight.intensity = midDayIntensity;
+            globalLight.color = midDayColor;
+            Debug.Log("[LightController] 씬 로드: 낮 상태로 조명 즉시 설정 완료.");
+        }
     }
 }

--- a/Assets/Scripts/Manager/FadeManager.cs
+++ b/Assets/Scripts/Manager/FadeManager.cs
@@ -81,7 +81,7 @@ public class FadeManager : MonoBehaviour
         }
 
         // 5. 씬 전환 후, 게임 전체 상태(전역 라이트) 재적용
-        GameManager.Instance?.ApplyGlobalLight();
+       GameManager.Instance?.ApplyGlobalLight(true);
 
         // 6. 화면 밝게
         yield return StartCoroutine(Fade(1f, 0f));

--- a/Assets/Scripts/Manager/GameManager.cs
+++ b/Assets/Scripts/Manager/GameManager.cs
@@ -262,17 +262,18 @@ public void PlayerDied()
     {
         switch (day)
         {
-            case GameDays.FirstDay: 
+           case GameDays.FirstDay: 
                     // 1일차: 낮 7분 (420초), 밤 3분 (180초)
-                   return (180f, 180f);
+                   return (420f, 180f);
                 case GameDays.SecondDay: 
                     // 2일차: 낮 6분 (360초), 밤 4분 (240초)
-                    return (180f, 180f);
+                    return (360f, 240f);
                 case GameDays.ThirdDay: 
                     // 3일차: 낮 5분 (300초), 밤 5분 (300초)
-                    return (180f, 180f);
+                    return (300f, 300f);
                 default:
-                    return (120f, 180f); // 안전 반환값
+                    // 혹시 모를 경우를 대비한 기본값
+                    return (180f, 180f);
         }
     }
 
@@ -288,16 +289,16 @@ public void PlayerDied()
             {
                 case GameDays.FirstDay: 
                     // 1일차: 낮 7분 (420초), 밤 3분 (180초)
-                   return (180f, 180f);
+                   return (420f, 180f);
                 case GameDays.SecondDay: 
                     // 2일차: 낮 6분 (360초), 밤 4분 (240초)
-                    return (180f, 180f);
+                    return (360f, 240f);
                 case GameDays.ThirdDay: 
                     // 3일차: 낮 5분 (300초), 밤 5분 (300초)
-                    return (180f, 180f);
+                    return (300f, 300f);
                 default:
                     // 혹시 모를 경우를 대비한 기본값
-                    return (120f, 180f);
+                    return (180f, 180f);
             }
         }
         

--- a/Assets/Scripts/Manager/GameManager.cs
+++ b/Assets/Scripts/Manager/GameManager.cs
@@ -98,6 +98,8 @@ public class GameManager : MonoBehaviour
 
     // 대화창 관련 플래그
     public bool IsDialogueActive { get; private set; } = false;
+    // 씬 로드 중 시간 흐름에 따른 조명 전환을 막는 플래그
+    public bool IsSceneLoadingInProgress { get; private set; } = false;
 
     // MARK: Awake 함수
     void Awake()
@@ -212,9 +214,16 @@ public void PlayerDied()
         StopCoroutine(gameLoopCoroutine);
 }
 
-    // MARK: 글로벌 라이트 적용
-    public void ApplyGlobalLight()
+   // MARK: 글로벌 라이트 적용
+    public void ApplyGlobalLight(bool isSceneLoad = false)
     {
+        // ⭐⭐ 추가: 씬 로드 중이고, 이것이 씬 로드 호출(isSceneLoad: true)이 아니라면 무시
+        if (IsSceneLoadingInProgress && !isSceneLoad)
+        {
+             Debug.LogWarning("[GameManager] 씬 로드 초기화 중이므로, 시간 흐름에 따른 조명 전환 요청을 무시합니다.");
+             return;
+        }
+
         string currentScene = SceneManager.GetActiveScene().name;
 
         if (currentScene == ShelterSceneName)
@@ -225,16 +234,26 @@ public void PlayerDied()
 
         if (currentScene == MainWorldSceneName)
         {
-            // LightController가 외부에서 정의되어 있다고 가정하고 주석 처리
             if (LightController.Instance != null)
             {
-                LightController.Instance.UpdateGlobalLight(CurrentPhase); 
+                if (isSceneLoad)
+                {
+                    // 씬 로드 시 (쉘터 복귀 등)에는 복잡한 전환 없이 즉시 최종 조명 상태를 설정
+                    LightController.Instance.SetGlobalLightInstantly(CurrentPhase); 
+                    Debug.Log($"[GameManager] 메인 씬 복귀: {CurrentPhase} 상태 조명 즉시 설정 완료.");
+                }
+                else
+                {
+                    // 게임 루프에 의한 페이즈 전환 시에는 복합 전환 사용
+                    LightController.Instance.UpdateGlobalLight(CurrentPhase); 
+                    Debug.Log($"[GameManager] 페이즈 전환: {CurrentPhase} 상태 조명 전환 시작.");
+                }
             }
             else
             {
                 Debug.LogWarning("[GameManager] Main 씬이지만 LightController.Instance를 찾을 수 없습니다.");
             }
-           
+        
         }
     }
 
@@ -259,6 +278,7 @@ public void PlayerDied()
 
  // TODO: 일차별 시간대 설정 (반드시 GetDurationForDay 동일하게 수정해줘야함)
 // MARK: 전체 게임 루프 코루틴 (일차별 시간 조정)
+   // MARK: 전체 게임 루프 코루틴 (일차별 시간 조정)
     IEnumerator GameLoopCoroutine()
     {
         // ⭐ DayDuration과 NightDuration을 동적으로 가져오는 헬퍼 함수
@@ -300,7 +320,9 @@ public void PlayerDied()
             // 좀비 수량 증가 (밤 페이즈 시작 시)
             CurrentZombieSpawnCount += 20; 
             Debug.Log($"🌙 [{CurrentDay}] 밤 시작! ({currentNightDuration/60f:F1}분 = {currentNightDuration:F0}초)");
-            ApplyGlobalLight();
+            
+            // ⭐ [수정 반영] 시간 흐름에 따른 전환이므로 인자 없이 호출
+            ApplyGlobalLight(); 
             
             // 밤 스폰 요청 (추가 스폰)
             StartNightPhase();
@@ -326,6 +348,8 @@ public void PlayerDied()
             (currentDayDuration, currentNightDuration) = GetDuration(CurrentDay); // 다음 날 시간 다시 가져옴
             CurrentPhase = Phase.Day;
             Debug.Log($"☀️ [{CurrentDay}] 낮 시작! ({currentDayDuration/60f:F1}분 = {currentDayDuration:F0}초)");
+            
+            // ⭐ [수정 반영] 시간 흐름에 따른 전환이므로 인자 없이 호출
             ApplyGlobalLight(); 
             
             // 낮 스폰 요청 (초기 스폰 - 씬 오브젝트 초기화 후)
@@ -341,6 +365,9 @@ public void PlayerDied()
 
         Debug.Log("모든 날이 종료되었습니다!");
     }
+
+
+
 
  // MARK: 납입 점수 기준에 따른 생존자 감소 계산
     private int CalculateSurvivorLoss()
@@ -785,9 +812,11 @@ void StartNightPhase()
         }
     }
     
-    // MARK: 씬 로드 시 실행 (UI 참조 복구 로직 강화 및 스폰 복원 총괄)
+   // MARK: 씬 로드 시 실행 (UI 참조 복구 로직 강화 및 스폰 복원 총괄)
     void OnSceneLoaded(Scene scene, LoadSceneMode mode)
     {
+        IsSceneLoadingInProgress = true;
+
         IsInShelter = (scene.name == ShelterSceneName); 
         
         // SpawnManager 인스턴스를 찾거나 참조를 유지합니다.
@@ -841,9 +870,10 @@ void StartNightPhase()
             }
         } 
         
-        ApplyGlobalLight(); 
+        // ⭐ [수정 반영] 씬 로드 직후이므로 true를 전달하여 LightController의 즉시 설정 함수 호출 유도
+        ApplyGlobalLight(true); 
+        IsSceneLoadingInProgress = false;
     }
-
     public void ResetGameSession()
     {
         Debug.Log("=========================================");

--- a/Assets/Scripts/Manager/QuestManager.cs
+++ b/Assets/Scripts/Manager/QuestManager.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using UnityEngine.UI;
 using System.Collections;
+using System.Collections.Generic; // List를 사용하지 않더라도 System.Collections.Generic는 유지
 
 public class QuestManager : MonoBehaviour
 {
@@ -91,6 +92,7 @@ public class QuestManager : MonoBehaviour
         // 4. 인벤토리 UI 활성화 
         if (InventoryUI.instance != null) 
         {
+            // InventoryUI.instance.OpenInventory()는 정의되어 있다고 가정합니다.
             InventoryUI.instance.OpenInventory();
             Debug.Log("[QuestManager] 퀘스트 제출 UI와 함께 인벤토리 UI를 열었습니다.");
         }
@@ -157,6 +159,7 @@ public void OnItemSubmitted(string itemName, int amountSubmitted, QuestSlot slot
         submitAmountText.text = $"수량: {slot.submittedCount} / {slot.RequiredAmount}";
 }
 
+
 // ───────────────────────────────
 // UI 닫기 (X 버튼 클릭 또는 완료 후 호출)
 
@@ -164,6 +167,7 @@ public void CloseSubmitUI()
 {
     Debug.Log("[CloseSubmitUI] 호출됨. 제출 UI와 대화 상태 정리 시작.");
 
+    // activeQuestData와 nextDialogueNodeIndex는 HandleQuestCompletion에서 초기화되지 않은 상태를 반영합니다.
     bool questWasCancelled = (activeQuestData != null); 
     bool dialogueIsResuming = nextDialogueNodeIndex != -1;
 
@@ -174,7 +178,7 @@ public void CloseSubmitUI()
         Debug.Log("[CloseSubmitUI] 퀘스트 미완료 취소: 슬롯 아이템을 인벤토리로 되돌렸습니다. (임시 상태 해제)");
     }
 
-    // 1. 대화 관리자 정리
+    // 1. 대화 관리자 정리 (취소 시 - 대화 미재개 상태일 때)
     if (questWasCancelled && !dialogueIsResuming) 
     {
         if (DialogueManager.Instance != null)
@@ -187,23 +191,23 @@ public void CloseSubmitUI()
         }
     }
     
-    // 2. GameManager.EndInteraction 호출 로직
+    // 2. GameManager.EndInteraction 호출 로직 (⭐ 수정된 핵심 로직 ⭐)
+    // 대화 재개 예정이 아닐 때만 상호작용 상태를 종료합니다.
     if (GameManager.Instance != null && !dialogueIsResuming) 
     {
-        if (activeQuestData == null)
-        {
-             GameManager.Instance.EndInteraction();
-             Debug.Log("[CloseSubmitUI] 퀘스트 완료 후 대화 미재개: 상호작용 수동 종료.");
-        }
+         GameManager.Instance.EndInteraction();
+         Debug.Log("[CloseSubmitUI] 대화 미재개 확정: 상호작용 수동 종료.");
     }
     else if (dialogueIsResuming)
     {
+         // 퀘스트 완료 후 대화가 이어질 예정이므로 EndInteraction()을 호출하지 않고 상호작용 상태를 유지합니다.
          Debug.Log("[CloseSubmitUI] 퀘스트 완료 후 대화 재개 예정이므로 상호작용 상태를 유지합니다.");
     }
 
     // 4. 인벤토리 UI 비활성화
     if (InventoryUI.instance != null) 
     {
+        // InventoryUI.instance.CloseInventory()는 정의되어 있다고 가정합니다.
         InventoryUI.instance.CloseInventory();
         Debug.Log("[CloseSubmitUI] 인벤토리 UI를 닫았습니다.");
     } else {
@@ -237,18 +241,22 @@ public void CloseSubmitUI()
         Debug.Log("[CloseSubmitUI] SubmitButton 리스너를 모두 제거했습니다.");
     }
     
+    // ⭐ 최종 상태 초기화: HandleQuestCompletion에서는 이 작업을 하지 않습니다.
     activeQuestData = null; 
     nextDialogueNodeIndex = -1;
 
     Debug.Log("[CloseSubmitUI] 상태 초기화 완료");
 }
 
+
 // 퀘스트 완료 후 보상 지급 및 상태 정리
 private void HandleQuestCompletion(QuestSlot slot)
 {
-    // ... (보상 로직 생략, 기존과 동일) ...
     QuestData data = slot.AssignedQuestData;
     
+    // ⭐ [추가]: 퀘스트 완료 후 NPC가 반복할 대화 노드의 인덱스 (0번으로 고정)
+    const int QUEST_COMPLETED_REPEAT_NODE_INDEX = 0; 
+
     if (data == null)
     {
         Debug.LogError("[HandleQuestCompletion] QuestData를 찾을 수 없습니다. 보상 지급 실패.");
@@ -262,6 +270,7 @@ private void HandleQuestCompletion(QuestSlot slot)
     {
         if (InventoryManager.Instance != null)
         {
+            // Item 클래스 인스턴스에서 InventoryManager가 요구하는 ItemData 에셋을 추출합니다. (기존 버전에서 ItemDataAsset을 사용했지만, 현재 버전은 slot.RewardItem을 직접 사용하는 것으로 가정하고 기존 코드를 유지합니다.)
             InventoryManager.Instance.AddRewardItemToInventory(slot.RewardItem, slot.RewardCount); 
             
             Debug.Log($"[HandleQuestCompletion] 아이템 보상 지급 완료: {slot.RewardItem.itemName} x{slot.RewardCount}");
@@ -285,6 +294,16 @@ private void HandleQuestCompletion(QuestSlot slot)
              Debug.LogError("[HandleQuestCompletion Error] GameManager.Instance가 Null입니다! 생존자 보상 지급 실패.");
         }
     }
+
+    // ⭐ [추가]: NPC에게 퀘스트 완료 상태를 영구적으로 설정
+    if (DialogueManager.Instance != null && DialogueManager.Instance.currentNPC != null) 
+    {
+        DialogueNPC currentNPC = DialogueManager.Instance.currentNPC;
+        
+        // DialogueNPC의 CompleteQuestState는 외부에서 정의되어 있다고 가정합니다.
+        currentNPC.CompleteQuestState(QUEST_COMPLETED_REPEAT_NODE_INDEX); 
+        Debug.Log($"[HandleQuestCompletion] NPC '{currentNPC.name}'의 퀘스트 완료 상태 설정 완료. 반복 노드: {QUEST_COMPLETED_REPEAT_NODE_INDEX}");
+    }
     
     // 3. 대화 재개 및 상호작용 유지 로직
     if (nextDialogueNodeIndex != -1)
@@ -306,7 +325,9 @@ private void HandleQuestCompletion(QuestSlot slot)
     {
          Debug.LogWarning("[HandleQuestCompletion] 다음 노드 인덱스가 없습니다. 상호작용 종료를 CloseSubmitUI에 위임합니다.");
     }
-
+    
+    // activeQuestData = null; 
+    // nextDialogueNodeIndex = -1;
     Debug.Log("[HandleQuestCompletion] 보상 지급 및 대화 명령 완료.");
 }
 


### PR DESCRIPTION
## 🚀 Background
- 퀘스트 오류 수정 (대화 재개 로직 관련)
- 쉘터 출입 시 낮/밤 페이즈 적용 오류 수정
- 시간대 변경

## 🥥 Changes
**쉘터 출입 시 낮/밤 페이즈 적용 오류 수정**
- 기존에는 '씬 전환' 기준으로 페이즈를 적용하다보니, 쉘터 출입 시 낮/밤 페이즈가 적용되어 낮일 경우 해가 뜨는 연출, 밤일 경우 해가 지는 연출이 적용되어 있었음.
`public void ApplyGlobalLight(bool isSceneLoad = false)`를 사용하여, 각 매니저에서 씬 전환 또는 일차 전환 관련하여 호출하여 사용하는 것으로 수정

**시간대 변경**
`GameManager.cs`에서 기존 기획대로 시간대 변경
- 1일차 : 낮 7분, 밤 3분
- 2일차 : 낮 6분, 밤 4분
- 3일차 : 낮 5분, 밤 5분

<img width="589" height="473" alt="스크린샷 2025-12-11 오후 8 37 45" src="https://github.com/user-attachments/assets/44d3e5c0-35b0-4265-aad1-e1c062ffcbe3" />

## 🪪 ID
- FR-001-2-2

## ⚓ Related Issue
- closes #218
