### PR TITLE
[FR-LOGIC/fix/#220] 생존자수 증가 퀘스트 보상 순서 변경

### DIFF
--- a/Assets/Scripts/Manager/DialogueManager.cs
+++ b/Assets/Scripts/Manager/DialogueManager.cs
@@ -172,6 +172,11 @@ public class DialogueManager : MonoBehaviour
         
         // 2. ⭐ [GameManager 상호작용 종료] 대화가 완전히 끝났을 때 상호작용 종료를 알립니다.
         GameManager.Instance?.EndInteraction();
+        if (GameManager.Instance != null)
+        {
+            GameManager.Instance.ExecuteReservedSurvivorIncrease();
+        }
+
         Debug.Log("[DialogueManager] 대화 상태 완전 초기화 완료.");
     }
 }

--- a/Assets/Scripts/Manager/GameManager.cs
+++ b/Assets/Scripts/Manager/GameManager.cs
@@ -100,6 +100,7 @@ public class GameManager : MonoBehaviour
     public bool IsDialogueActive { get; private set; } = false;
     // 씬 로드 중 시간 흐름에 따른 조명 전환을 막는 플래그
     public bool IsSceneLoadingInProgress { get; private set; } = false;
+    [HideInInspector] private int delayedSurvivorIncreaseAmount = 0;
 
     // MARK: Awake 함수
     void Awake()
@@ -923,6 +924,33 @@ void StartNightPhase()
         // 💡 필요한 경우 UI 업데이트 로직 호출 (예: HUD 또는 쉘터 UI)
         // if (ShelterUI.Instance != null) ShelterUI.Instance.UpdateSurvivorDisplay(SurvivorCount); 
     }
+
+    // MARK: 생존자 증가 보상 예약 함수 (QuestManager에서 호출)
+public void ReserveSurvivorIncrease(int amount)
+{
+    if (amount > 0)
+    {
+        delayedSurvivorIncreaseAmount += amount;
+        Debug.Log($"[GameManager] 생존자 증가 보상 {amount}명이 예약되었습니다. 현재 예약 누적: {delayedSurvivorIncreaseAmount}");
+    }
+}
+
+// MARK: 예약된 생존자 증가 보상 실행 함수 (DialogueManager에서 호출)
+public void ExecuteReservedSurvivorIncrease()
+{
+    if (delayedSurvivorIncreaseAmount > 0)
+    {
+        // AddSurvivors는 이미 SurvivorCount를 증가시키고 UI를 업데이트한다고 가정
+        AddSurvivors(delayedSurvivorIncreaseAmount); 
+        
+        Debug.Log($"[GameManager] 예약된 생존자 보상 {delayedSurvivorIncreaseAmount}명 지급 완료.");
+        
+        // 지급 후 반드시 예약량 초기화
+        delayedSurvivorIncreaseAmount = 0; 
+    }
+}
+
+
     // 대화 시작 시 호출
     public void StartInteraction()
     {

--- a/Assets/Scripts/Manager/QuestManager.cs
+++ b/Assets/Scripts/Manager/QuestManager.cs
@@ -282,16 +282,17 @@ private void HandleQuestCompletion(QuestSlot slot)
     }
     
     // 2. 생존자 증가 보상 처리
-    if (data.increaseSurvivors)
+   if (data.increaseSurvivors)
     {
         if (GameManager.Instance != null) 
         {
-            GameManager.Instance.AddSurvivors(data.survivorIncreaseAmount);
-            Debug.Log($"[HandleQuestCompletion] 생존자 수 증가 보상 지급 완료: {data.survivorIncreaseAmount}명 증가.");
+            // ⭐ AddSurvivors 대신 ReserveSurvivorIncrease 호출
+            GameManager.Instance.ReserveSurvivorIncrease(data.survivorIncreaseAmount);
+            Debug.Log($"[HandleQuestCompletion] 생존자 수 증가 보상 {data.survivorIncreaseAmount}명을 대화 종료 후 지급하도록 예약 완료.");
         }
         else
         {
-             Debug.LogError("[HandleQuestCompletion Error] GameManager.Instance가 Null입니다! 생존자 보상 지급 실패.");
+             Debug.LogError("[HandleQuestCompletion Error] GameManager.Instance가 Null입니다! 생존자 보상 예약 실패.");
         }
     }
 


### PR DESCRIPTION
## 🚀 Background
- 생존자수 증가 퀘스트 보상 순서 변경
- 현재는 **생존자와 대화 - 퀘스트창 열림 - 생존자와 대화 재개**로 구성되어 있는데, 생존자수 증가의 경우 퀘스트창에 아이템 제출 성공하자마자 바로 생존자수가 +1이 되어서, 어색함을 없애기 위해 모든 대화 종료 이후 생존자수 증가로 변경

## 🥥 Changes
- `QuestManager.cs`에서 아이템 납입에 성공하면,`GameManager.cs`에서 생존자 증가 보상을 예약 후, 대화창 종료 시 `DialogueManager.cs`에서 호출하여 생존자수 증가
```
 // MARK: 생존자 증가 보상 예약 함수 (QuestManager에서 호출)
    public void ReserveSurvivorIncrease(int amount)
    {
        if (amount > 0)
        {
            delayedSurvivorIncreaseAmount += amount;
            Debug.Log($"[GameManager] 생존자 증가 보상 {amount}명이 예약되었습니다. 현재 예약 누적: {delayedSurvivorIncreaseAmount}");
        }
    }

    // MARK: 예약된 생존자 증가 보상 실행 함수 (DialogueManager에서 호출)
    public void ExecuteReservedSurvivorIncrease()
    {
        if (delayedSurvivorIncreaseAmount > 0)
        {
            // AddSurvivors는 이미 SurvivorCount를 증가시키고 UI를 업데이트한다고 가정
            AddSurvivors(delayedSurvivorIncreaseAmount); 
            
            Debug.Log($"[GameManager] 예약된 생존자 보상 {delayedSurvivorIncreaseAmount}명 지급 완료.");
            
            // 지급 후 반드시 예약량 초기화
            delayedSurvivorIncreaseAmount = 0; 
        }
    }
```

## 📸 Screenshots
https://github.com/user-attachments/assets/86ee41b5-1df5-4839-bfa0-9e367fdb2de4

## 🪪 ID
- FR-011-2-1
- FR-011-2-2
- FR-011-2-3

## ⚓ Related Issue
- closes #220
