### PR TITLE
[FR-LOGIC/fix/#226] 조합 NPC 및 교환 NPC의 경우 무조건 소환

### DIFF
--- a/Assets/Scripts/Manager/SpawnManager.cs
+++ b/Assets/Scripts/Manager/SpawnManager.cs
@@ -482,7 +482,7 @@ public class SpawnManager : MonoBehaviour
     }
 
 
-    // MARK: 아이템, NPC, 좀비 스폰 함수 (🌟 영구 데이터가 없을 때만 실행)
+   // MARK: 아이템, NPC, 좀비 스폰 함수 (🌟 영구 데이터가 없을 때만 실행)
     public void StartSpawnProcess(int totalItemCount, int npcCount, int zombieCount)
     {
         // 🚨 수정: 아이템/NPC 영구 데이터가 있다면 초기 스폰 전체를 건너뜁니다.
@@ -708,34 +708,82 @@ public class SpawnManager : MonoBehaviour
         Debug.Log($"[SpawnManager] 2단계: 확률적 아이템 {remainingItemsToSpawn}개 스폰 시도. 실제 스폰된 아이템 총 {spawnedItemCount}개.");
 
 
-        // 3. NPC 스폰 및 Persistent NPC Data 기록 (기존 로직 유지)
-        int actualNpcCount = Mathf.Min(npcCount, npcPrefabs.Length); 
+        // ---------------------------------------------------------------------------------
+        // ⭐ [수정된 3단계]: NPC 스폰 (고정 2명 + 일반 최대 5명)
+        // ---------------------------------------------------------------------------------
+        
+        // 고정 소환할 NPC 목록 (프리팹 이름으로 식별)
+        string[] requiredNpcNames = { "ExchangeNPC", "RecipeNPC" }; 
+        List<GameObject> availableNpcs = new List<GameObject>(npcPrefabs);
+        List<GameObject> npcsToSpawn = new List<GameObject>();
+        int totalNpcSpawned = 0;
 
-        if (npcPrefabs.Length == 0) 
+        // 3-1. 고정 NPC 무조건 스폰 및 영구 데이터 기록 (2명)
+        foreach (string requiredName in requiredNpcNames)
         {
-            Debug.LogWarning("[SpawnManager] 스폰할 NPC 프리팹이 지정되지 않았습니다.");
+            GameObject requiredPrefab = GetNpcPrefabByName(requiredName); 
+
+            if (requiredPrefab != null)
+            {
+                if (remainingPositions.Count == 0)
+                {
+                    Debug.LogWarning($"[SpawnManager] 고정 NPC '{requiredName}' 스폰 시도 실패: 스폰 가능한 위치가 없습니다.");
+                    break; 
+                }
+
+                // SpawnObjects를 사용하여 생성 및 persistentNPCs에 기록
+                List<Vector3> usedPos = SpawnObjects(requiredPrefab, 1, remainingPositions, spawnedNPCs); 
+                remainingPositions.RemoveAll(pos => usedPos.Contains(pos));
+                
+                // availableNpcs 리스트에서 해당 프리팹을 제거하여 3-2단계에서 중복 스폰 방지
+                availableNpcs.RemoveAll(p => p != null && p.name.Replace("(Clone)", "").Trim() == requiredName);
+                totalNpcSpawned++;
+
+                Debug.Log($"[SpawnManager] 고정 NPC '{requiredName}' 스폰 완료.");
+            }
+            else
+            {
+                Debug.LogWarning($"[SpawnManager] 고정 NPC '{requiredName}' 프리팹을 npcPrefabs에서 찾을 수 없습니다.");
+            }
         }
-        else
+
+        // 3-2. 일반 NPC 추가 스폰 (나머지 NPC 중 최대 5명)
+        const int additionalNpcCount = 5;
+        int actualAdditionalCount = 0; 
+        int currentAvailableNpcCount = availableNpcs.Count;
+
+        // 스폰할 수 있는 최대 인원은 '남은 NPC 수' 또는 '요청된 추가 수(5명)' 중 작은 값
+        int countToSelect = Mathf.Min(additionalNpcCount, currentAvailableNpcCount); 
+
+        for (int i = 0; i < countToSelect; i++)
         {
-            List<GameObject> npcsToSpawn = new List<GameObject>();
-            List<GameObject> availableNpcs = new List<GameObject>(npcPrefabs);
+            if (availableNpcs.Count == 0) break;
+
+            int randomIndex = Random.Range(0, availableNpcs.Count);
+            GameObject selectedNpc = availableNpcs[randomIndex];
+
+            npcsToSpawn.Add(selectedNpc);
+            availableNpcs.RemoveAt(randomIndex); // 중복 방지를 위해 제거
+        }
+
+        // 선택된 일반 NPC들을 스폰합니다.
+        foreach (GameObject npcPrefab in npcsToSpawn)
+        {
+            if (remainingPositions.Count == 0)
+            {
+                Debug.LogWarning($"[SpawnManager] 일반 NPC '{npcPrefab.name}' 스폰 시도 실패: 스폰 가능한 위치가 없습니다.");
+                break;
+            }
             
-            for (int i = 0; i < actualNpcCount; i++)
-            {
-                if (availableNpcs.Count == 0) break;
-
-                int randomIndex = Random.Range(0, availableNpcs.Count);
-                npcsToSpawn.Add(availableNpcs[randomIndex]);
-                availableNpcs.RemoveAt(randomIndex); 
-            }
-
-            foreach (GameObject npcPrefab in npcsToSpawn)
-            {
-                // SpawnObjects를 사용하여 생성 및 persistentNPCs에 (미완료 상태로) 기록
-                List<Vector3> usedNpcPositions = SpawnObjects(npcPrefab, 1, remainingPositions, spawnedNPCs); 
-                remainingPositions.RemoveAll(pos => usedNpcPositions.Contains(pos));
-            }
+            // SpawnObjects를 사용하여 생성 및 persistentNPCs에 (미완료 상태로) 기록
+            List<Vector3> usedNpcPositions = SpawnObjects(npcPrefab, 1, remainingPositions, spawnedNPCs); 
+            remainingPositions.RemoveAll(pos => usedNpcPositions.Contains(pos));
+            actualAdditionalCount++;
+            totalNpcSpawned++;
         }
+
+        Debug.Log($"[SpawnManager] 3단계: NPC 스폰 완료. 총 {totalNpcSpawned}명 (고정 2명 + 일반 {actualAdditionalCount}명).");
+
 
         // 4. 좀비 스폰 (기존 로직 유지)
         Debug.Log($"[SpawnManager] 4단계: 초기 좀비 스폰 시작: {zombieCount}마리 (Normal).");
@@ -743,7 +791,7 @@ public class SpawnManager : MonoBehaviour
         remainingPositions.RemoveAll(pos => usedZombiePositions.Contains(pos));
         Debug.Log($"[SpawnManager] 초기 좀비 스폰 완료: {usedZombiePositions.Count}마리.");
     }
-    
+
     // MARK: 좀비만 스폰 (밤 페이즈용 - 기존 좀비를 유지하고 추가 스폰)
     public void SpawnZombiesOnly(int totalTargetZombieCount)
     {

--- a/Assets/Scripts/Quest/ExchangeQuestData/Exchage1.asset
+++ b/Assets/Scripts/Quest/ExchangeQuestData/Exchage1.asset
@@ -15,8 +15,11 @@ MonoBehaviour:
   questName: Exchange1
   questDescription: "\uC694\uAD6C \uC544\uC774\uD15C\uACFC \uBCF4\uC0C1 \uC544\uC774\uD15C\uC774
     \uC124\uC815\uB429\uB2C8\uB2E4."
-  requiredItemName: Can
-  requiredItemIcon: {fileID: 7032184553362833509, guid: 38c3d8231c4eb73478464217531b4925, type: 3}
-  requiredAmount: 2
-  rewardItem: {fileID: -5984088972931491910, guid: 5d9a4a6bb9122432497b32b9a6cdd7e4, type: 3}
+  requiredItemName: Band
+  requiredItemIcon: {fileID: 1462799768519014029, guid: 9c77f37515354464aae966cdb8782afa, type: 3}
+  requiredAmount: 3
+  giveItemReward: 0
+  rewardItem: {fileID: -5417729018282012106, guid: fd3b8b600e994fc44abd4eefaf5b1b07, type: 3}
   rewardCount: 2
+  increaseSurvivors: 0
+  survivorIncreaseAmount: 1

--- a/Assets/Scripts/Quest/ExchangeQuestData/Exchange2.asset
+++ b/Assets/Scripts/Quest/ExchangeQuestData/Exchange2.asset
@@ -17,6 +17,9 @@ MonoBehaviour:
     \uC124\uC815\uB429\uB2C8\uB2E4."
   requiredItemName: Water
   requiredItemIcon: {fileID: 6049605792901559095, guid: aac519b06e4484c4399686d58ca83138, type: 3}
-  requiredAmount: 1
+  requiredAmount: 3
+  giveItemReward: 0
   rewardItem: {fileID: -8838197168880746185, guid: de5ea7b0032b64ef5bd4e7835c50934a, type: 3}
-  rewardCount: 1
+  rewardCount: 3
+  increaseSurvivors: 0
+  survivorIncreaseAmount: 1

--- a/Assets/Scripts/Quest/ExchangeQuestData/Exchange3.asset
+++ b/Assets/Scripts/Quest/ExchangeQuestData/Exchange3.asset
@@ -15,8 +15,11 @@ MonoBehaviour:
   questName: Exchange3
   questDescription: "\uC694\uAD6C \uC544\uC774\uD15C\uACFC \uBCF4\uC0C1 \uC544\uC774\uD15C\uC774
     \uC124\uC815\uB429\uB2C8\uB2E4."
-  requiredItemName: FirstAidKit
-  requiredItemIcon: {fileID: 1142586732419344882, guid: 7e4b87674c09cec4e8f5306a0fa018a7, type: 3}
-  requiredAmount: 1
-  rewardItem: {fileID: 8018865339420979663, guid: 778e4e19c7c893142b94cdd7daaf9a1b, type: 3}
-  rewardCount: 2
+  requiredItemName: Battery
+  requiredItemIcon: {fileID: -3017979480325208809, guid: 604963de1e5ba524188ed531a4088ce6, type: 3}
+  requiredAmount: 6
+  giveItemReward: 0
+  rewardItem: {fileID: -8838197168880746185, guid: de5ea7b0032b64ef5bd4e7835c50934a, type: 3}
+  rewardCount: 3
+  increaseSurvivors: 0
+  survivorIncreaseAmount: 1

--- a/Assets/Scripts/Quest/ExchangeQuestData/Exchange4.asset
+++ b/Assets/Scripts/Quest/ExchangeQuestData/Exchange4.asset
@@ -15,8 +15,11 @@ MonoBehaviour:
   questName: Exchange3
   questDescription: "\uC694\uAD6C \uC544\uC774\uD15C\uACFC \uBCF4\uC0C1 \uC544\uC774\uD15C\uC774
     \uC124\uC815\uB429\uB2C8\uB2E4."
-  requiredItemName: Band
-  requiredItemIcon: {fileID: 1462799768519014029, guid: 9c77f37515354464aae966cdb8782afa, type: 3}
-  requiredAmount: 1
-  rewardItem: {fileID: 1117397670487763955, guid: ac2e620bd2cab82478a9238d650e170e, type: 3}
+  requiredItemName: WoodPanel
+  requiredItemIcon: {fileID: -8772241969766799354, guid: 336e235656992384abf1362ec0a8d24d, type: 3}
+  requiredAmount: 4
+  giveItemReward: 0
+  rewardItem: {fileID: 8018865339420979663, guid: 778e4e19c7c893142b94cdd7daaf9a1b, type: 3}
   rewardCount: 2
+  increaseSurvivors: 0
+  survivorIncreaseAmount: 1

--- a/Assets/Scripts/Quest/ExchangeQuestData/Exchange5.asset
+++ b/Assets/Scripts/Quest/ExchangeQuestData/Exchange5.asset
@@ -17,6 +17,9 @@ MonoBehaviour:
     \uC124\uC815\uB429\uB2C8\uB2E4."
   requiredItemName: FirstAidKit
   requiredItemIcon: {fileID: 1142586732419344882, guid: 7e4b87674c09cec4e8f5306a0fa018a7, type: 3}
-  requiredAmount: 2
+  requiredAmount: 5
+  giveItemReward: 0
   rewardItem: {fileID: 7779567416236938931, guid: beb082c413c1f104f8119f9ed4d323e1, type: 3}
   rewardCount: 1
+  increaseSurvivors: 0
+  survivorIncreaseAmount: 1


### PR DESCRIPTION
## 🚀 Background
- 현재는 총 10명의 NPC 중 5명의 NPC를 랜덤 소환하는데, 그중 조합 NPC 및 교환 NPC는 무조건 소환 (위치는 랜덤)
- 조합 NPC 및 교환 NPC 매일차마다 무조건 소환 (2명)
- 다른 종류의 NPC 5명 추가 소환

## ⚓ Related Issue
- closes #226 
