### PR TITLE
[FR-all-check/fix] : 좀비 드랍 아이템 확률 수정

### DIFF
--- a/Assets/Prefabs/ZombiePrefabs/NormalZombie.prefab
+++ b/Assets/Prefabs/ZombiePrefabs/NormalZombie.prefab
@@ -117,6 +117,8 @@ MonoBehaviour:
     dropRate: 0.1
   - itemPrefab: {fileID: 4395095357716272013, guid: 425a1d701a7b0fe43b0e979d3247ac22, type: 3}
     dropRate: 0.1
+  - itemPrefab: {fileID: 9042649337361522645, guid: 636bd03e8d9f75c48a70e92071664bc9, type: 3}
+    dropRate: 0.1
   dropItem: {fileID: 1296834444985638504, guid: 7f140e7a38ddecd48bccfdb655f6529b, type: 3}
   dropRate: 0.1
   BaseHp: 1000

--- a/Assets/Scripts/Manager/GameManager.cs
+++ b/Assets/Scripts/Manager/GameManager.cs
@@ -218,7 +218,7 @@ public void PlayerDied()
    // MARK: 글로벌 라이트 적용
     public void ApplyGlobalLight(bool isSceneLoad = false)
     {
-        // ⭐⭐ 추가: 씬 로드 중이고, 이것이 씬 로드 호출(isSceneLoad: true)이 아니라면 무시
+        // 씬 로드 중이고, 이것이 씬 로드 호출(isSceneLoad: true)이 아니라면 무시
         if (IsSceneLoadingInProgress && !isSceneLoad)
         {
              Debug.LogWarning("[GameManager] 씬 로드 초기화 중이므로, 시간 흐름에 따른 조명 전환 요청을 무시합니다.");
@@ -268,10 +268,10 @@ public void PlayerDied()
                    return (420f, 180f);
                 case GameDays.SecondDay: 
                     // 2일차: 낮 6분 (360초), 밤 4분 (240초)
-                    return (360f, 240f);
+                    return (300f, 240f);
                 case GameDays.ThirdDay: 
                     // 3일차: 낮 5분 (300초), 밤 5분 (300초)
-                    return (300f, 300f);
+                    return (240f, 300f);
                 default:
                     // 혹시 모를 경우를 대비한 기본값
                     return (180f, 180f);
@@ -290,13 +290,13 @@ public void PlayerDied()
             {
                 case GameDays.FirstDay: 
                     // 1일차: 낮 7분 (420초), 밤 3분 (180초)
-                   return (300f, 180f);
+                   return (420f, 180f);
                 case GameDays.SecondDay: 
                     // 2일차: 낮 6분 (360초), 밤 4분 (240초)
-                    return (240f, 180f);
+                    return (300f, 240f);
                 case GameDays.ThirdDay: 
                     // 3일차: 낮 5분 (300초), 밤 5분 (300초)
-                    return (180f, 180f);
+                    return (240f, 300f);
                 default:
                     // 혹시 모를 경우를 대비한 기본값
                     return (180f, 180f);

--- a/Assets/Scripts/Manager/SpawnManager.cs
+++ b/Assets/Scripts/Manager/SpawnManager.cs
@@ -408,22 +408,22 @@ public class SpawnManager : MonoBehaviour
                     npcComponent.RestoreState(npcData.isQuestCompleted, npcData.repeatDialogueNodeIndex); 
                 }
                 
-                // ⭐ [추가] 복원된 NPC는 유지할 목록에 추가
+                // 복원된 NPC는 유지할 목록에 추가
                 npcsToKeep.Add(npcData);
             }
         }
         
-        // ⭐ [추가] 영구 데이터 리스트를 유지할 NPC 목록으로 덮어씁니다. (실제 영구 제거)
+        // 영구 데이터 리스트를 유지할 NPC 목록으로 덮어씁니다 (실제 영구 제거)
         persistentNPCs = npcsToKeep;
         
-        // 🚨 3. 좀비 강제 스폰 (아이템/NPC 복원 직후 낮 좀비 스폰 보장)
+        // 3. 좀비 강제 스폰 (아이템/NPC 복원 직후 낮 좀비 스폰 보장)
         Debug.Log($"[SpawnManager] 복원 후 낮 좀비 스폰 강제 실행: {defaultDayZombieCount}마리.");
         SpawnZombiesDuringRestore(defaultDayZombieCount, occupiedPositions);
         
         Debug.Log($"[SpawnManager] 오브젝트 복원 및 좀비 스폰 완료: 아이템 {spawnedItems.Count}개, NPC {restoredNpcCount}명, 좀비 {spawnedZombies.Count}마리");
     }
 
-    // 🚨 좀비 스폰 로직 분리 (복원 시 사용)
+    // 좀비 스폰 로직 (쉘터 복원 시 사용)
     private void SpawnZombiesDuringRestore(int zombieCount, List<Vector3> occupiedPositions)
     {
         if (allSpawnPositions.Count == 0)
@@ -441,12 +441,40 @@ public class SpawnManager : MonoBehaviour
         // 아이템/NPC가 복원된 위치 제외
         remainingPositions.RemoveAll(pos => occupiedPositions.Contains(pos));
 
-        // 좀비 스폰 (낮에는 일반 좀비만 스폰)
-        List<Vector3> usedZombiePositions = SpawnObjects(normalZombiePrefab, zombieCount, remainingPositions, spawnedZombies);
+        // 현재 날짜에 따라 특수좀비 스폰 여부 결정 (2일차 이상부터 특수좀비 스폰)
+        bool shouldSpawnSpecialZombies = GameManager.Instance != null && GameManager.Instance.CurrentDay >= GameDays.SecondDay;
         
-        if (usedZombiePositions.Count < zombieCount)
+        if (shouldSpawnSpecialZombies)
         {
-            Debug.LogWarning($"[SpawnManager] 요청된 좀비 수({zombieCount})보다 적은 수({usedZombiePositions.Count})의 좀비만 스폰되었습니다. (위치 부족)");
+            // 2일차 이상: Normal, HighSpeed, HighPower 세 종류에 균등하게 분배
+            int countPerType = zombieCount / 3;
+            int normalCount = countPerType;
+            int highSpeedCount = countPerType;
+            int highPowerCount = zombieCount - normalCount - highSpeedCount;
+
+            // Normal 좀비 스폰
+            List<Vector3> usedNormalPositions = SpawnObjects(normalZombiePrefab, normalCount, remainingPositions, spawnedZombies);
+            remainingPositions.RemoveAll(pos => usedNormalPositions.Contains(pos));
+
+            // HighSpeed 좀비 스폰
+            List<Vector3> usedSpeedPositions = SpawnObjects(highSpeedZombiePrefab, highSpeedCount, remainingPositions, spawnedZombies);
+            remainingPositions.RemoveAll(pos => usedSpeedPositions.Contains(pos));
+
+            // HighPower 좀비 스폰
+            List<Vector3> usedPowerPositions = SpawnObjects(highPowerZombiePrefab, highPowerCount, remainingPositions, spawnedZombies);
+            
+            Debug.Log($"[SpawnManager] 복원 시 좀비 스폰 완료 (2일차 이상): Normal {usedNormalPositions.Count}마리, HighSpeed {usedSpeedPositions.Count}마리, HighPower {usedPowerPositions.Count}마리");
+        }
+        else
+        {
+            // 1일차: Normal 좀비만 스폰
+            List<Vector3> usedZombiePositions = SpawnObjects(normalZombiePrefab, zombieCount, remainingPositions, spawnedZombies);
+            Debug.Log($"[SpawnManager] 복원 시 좀비 스폰 완료 (1일차): Normal {usedZombiePositions.Count}마리");
+            
+            if (usedZombiePositions.Count < zombieCount)
+            {
+                Debug.LogWarning($"[SpawnManager] 요청된 좀비 수({zombieCount})보다 적은 수({usedZombiePositions.Count})의 좀비만 스폰되었습니다. (위치 부족)");
+            }
         }
     }
 

--- a/Assets/Scripts/ZombieStat.cs
+++ b/Assets/Scripts/ZombieStat.cs
@@ -226,15 +226,29 @@ public class ZombieStat : MonoBehaviour
             float selectedValue = Random.Range(0f, totalRate);
             float currentSum = 0f;
 
-            foreach (var item in validItems)
+            for (int i = 0; i < validItems.Count; i++)
             {
+                var item = validItems[i];
+                float previousSum = currentSum;
                 currentSum += item.dropRate;
-                if (selectedValue <= currentSum)
+                
+                // selectedValue가 이 아이템의 범위에 속하는지 확인
+                // previousSum < selectedValue <= currentSum
+                if (selectedValue > previousSum && selectedValue <= currentSum)
                 {
                     // 이 아이템 드롭
                     Instantiate(item.itemPrefab, transform.position, Quaternion.identity);
-                    break;
+                    Debug.Log($"[ZombieStat] 아이템 드롭: {item.itemPrefab.name} (인덱스 {i}, 확률 {item.dropRate}, 선택값 {selectedValue:F3}, 범위 {previousSum:F3}~{currentSum:F3})");
+                    return;
                 }
+            }
+            
+            // 마지막 아이템이 선택되지 않았으면 (부동소수점 오차로 인한 경우) 마지막 아이템 드롭
+            if (validItems.Count > 0)
+            {
+                var lastItem = validItems[validItems.Count - 1];
+                Instantiate(lastItem.itemPrefab, transform.position, Quaternion.identity);
+                Debug.Log($"[ZombieStat] 아이템 드롭 (마지막): {lastItem.itemPrefab.name} (선택값 {selectedValue:F3}, 총합 {totalRate:F3})");
             }
         }
         // 기존 dropItem 필드 (하위 호환성 유지)


### PR DESCRIPTION
## 🚀 Background
- 일반 좀비 드랍 아이템 확률 수정
-> 기존에 확률이 파밍이 너무 쉬워지는 거 같아서 아이템 드롭 확률 감소
- 특수좀비 능력치 소폭 상향

## 🥥 Changes
- 이전 브렌치에서 수정했던 스탯들을 플레이 하는 과정에서 다시 수정
- 특수 좀비들의 체력이 낮아서 낮이도 체감이 덜했던 문제가 있어서 특수 좀비들의 체력 2배씩 증가